### PR TITLE
Fully document the public API of rocket_okapi

### DIFF
--- a/rocket-okapi-codegen/src/lib.rs
+++ b/rocket-okapi-codegen/src/lib.rs
@@ -11,6 +11,20 @@ mod routes_with_openapi;
 use proc_macro::TokenStream;
 use syn::Ident;
 
+/// A proc macro to be used in tandem with one of `Rocket`'s endpoint macros. It requires that all
+/// of the arguments of the route implement one of the traits in `rocket_okapi::request`, and that
+/// the return type implements `OpenApiResponder`.
+/// ### Example
+/// ```
+/// use rocket_okapi::openapi;
+/// use rocket::get;
+///
+/// #[openapi]
+/// #[get("/hello/<number>")]
+/// fn hello_world(number: i32) -> String {
+///     format!("Hellow world number {}", number)
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn openapi(args: TokenStream, mut input: TokenStream) -> TokenStream {
     // We don't need to modify/replace the input TokenStream,
@@ -19,6 +33,10 @@ pub fn openapi(args: TokenStream, mut input: TokenStream) -> TokenStream {
     input
 }
 
+/// A replacement macro for `rocket::routes`. The key differences are that this macro will add an
+/// additional element to the resulting `Vec<rocket::Route>`, which serves a static file called
+/// `openapi.json`. This file can then be used to display the routes in the swagger ui. Note that
+/// this macro requires [schemars](https://docs.rs/schemars) to be in scope.
 #[proc_macro]
 pub fn routes_with_openapi(input: TokenStream) -> TokenStream {
     routes_with_openapi::parse(input)

--- a/rocket-okapi-codegen/src/lib.rs
+++ b/rocket-okapi-codegen/src/lib.rs
@@ -35,8 +35,7 @@ pub fn openapi(args: TokenStream, mut input: TokenStream) -> TokenStream {
 
 /// A replacement macro for `rocket::routes`. The key differences are that this macro will add an
 /// additional element to the resulting `Vec<rocket::Route>`, which serves a static file called
-/// `openapi.json`. This file can then be used to display the routes in the swagger ui. Note that
-/// this macro requires [schemars](https://docs.rs/schemars) to be in scope.
+/// `openapi.json`. This file can then be used to display the routes in the swagger ui.
 #[proc_macro]
 pub fn routes_with_openapi(input: TokenStream) -> TokenStream {
     routes_with_openapi::parse(input)

--- a/rocket-okapi-codegen/src/lib.rs
+++ b/rocket-okapi-codegen/src/lib.rs
@@ -15,7 +15,7 @@ use syn::Ident;
 /// of the arguments of the route implement one of the traits in `rocket_okapi::request`, and that
 /// the return type implements `OpenApiResponder`.
 /// ### Example
-/// ```
+/// ```rust,ignore
 /// use rocket_okapi::openapi;
 /// use rocket::get;
 ///

--- a/rocket-okapi/src/error.rs
+++ b/rocket-okapi/src/error.rs
@@ -1,14 +1,17 @@
 use std::error::Error;
 use std::fmt;
 
+/// Type alias for `Result<T, OpenApiError>`.
 pub type Result<T> = std::result::Result<T, OpenApiError>;
 
+/// The error type returned by `rocket_okapi` when something fails.
 #[derive(Debug, Clone)]
 pub struct OpenApiError {
     msg: String,
 }
 
 impl OpenApiError {
+    /// Create a new `OpenApiError` containing a message.
     pub fn new(msg: String) -> Self {
         OpenApiError { msg }
     }

--- a/rocket-okapi/src/gen.rs
+++ b/rocket-okapi/src/gen.rs
@@ -9,6 +9,7 @@ use schemars::JsonSchema;
 use std::collections::{hash_map::Entry as HashEntry, HashMap};
 use std::iter::FromIterator;
 
+/// A struct that visits all `rocket::Route`s, and aggregates information about them.
 #[derive(Debug, Clone)]
 pub struct OpenApiGenerator {
     settings: OpenApiSettings,
@@ -17,6 +18,7 @@ pub struct OpenApiGenerator {
 }
 
 impl OpenApiGenerator {
+    /// Create a new `OpenApiGenerator` from the settings provided.
     pub fn new(settings: OpenApiSettings) -> Self {
         OpenApiGenerator {
             schema_generator: settings.schema_settings.clone().into_generator(),
@@ -25,6 +27,7 @@ impl OpenApiGenerator {
         }
     }
 
+    /// Add a new `HTTP Method` to the collection of endpoints in the `OpenApiGenerator`.
     pub fn add_operation(&mut self, mut op: OperationInfo) {
         if let Some(op_id) = op.operation.operation_id {
             // TODO do this outside add_operation
@@ -42,14 +45,17 @@ impl OpenApiGenerator {
         };
     }
 
+    /// Generate the final `JsonSchema` from all added operations.
     pub fn json_schema<T: ?Sized + JsonSchema>(&mut self) -> SchemaObject {
         self.schema_generator.subschema_for::<T>().into()
     }
 
+    /// Obtain the internal `SchemaGenerator` object.
     pub fn schema_generator(&self) -> &SchemaGenerator {
         &self.schema_generator
     }
 
+    /// Generate an `OpenApi` specification for all added operations.
     pub fn into_openapi(self) -> OpenApi {
         OpenApi {
             openapi: "3.0.0".to_owned(),

--- a/rocket-okapi/src/handlers/content.rs
+++ b/rocket-okapi/src/handlers/content.rs
@@ -3,12 +3,15 @@ use rocket::http::{ContentType, Method};
 use rocket::response::{Content, Responder};
 use rocket::{Data, Request, Route};
 
+/// A content handler is a wrapper type around `rocket::response::Content`, which can be turned into
+/// a `rocket::Route` that serve the content with correct content_type.
 #[derive(Clone)]
 pub struct ContentHandler<R: Responder<'static> + Clone + Send + Sync + 'static> {
     content: Content<R>,
 }
 
 impl ContentHandler<String> {
+    /// Create a `ContentHandle<String>` which serves its content as `JSON`.
     pub fn json(content: &impl serde::Serialize) -> Self {
         let json =
             serde_json::to_string_pretty(content).expect("Could not serialize content as JSON.");
@@ -19,6 +22,8 @@ impl ContentHandler<String> {
 }
 
 impl ContentHandler<&'static [u8]> {
+    /// Create a `ContentHandler<&[u8]>`, which serves its content with the specified
+    /// `content_type`.
     pub fn bytes(content_type: ContentType, content: &'static [u8]) -> Self {
         ContentHandler {
             content: Content(content_type, content),
@@ -27,6 +32,7 @@ impl ContentHandler<&'static [u8]> {
 }
 
 impl<R: Responder<'static> + Clone + Send + Sync + 'static> ContentHandler<R> {
+    /// Create a `rocket::Route` from the current `ContentHandler`.
     pub fn into_route(self, path: impl AsRef<str>) -> Route {
         Route::new(Method::Get, path, self)
     }

--- a/rocket-okapi/src/handlers/openapi.rs
+++ b/rocket-okapi/src/handlers/openapi.rs
@@ -4,16 +4,19 @@ use rocket::http::{ContentType, Method};
 use rocket::response::Content;
 use rocket::{Data, Request, Route};
 
+/// A handler type that is used to serve the `openapi.json` files.
 #[derive(Clone)]
 pub struct OpenApiHandler {
     spec: OpenApi,
 }
 
 impl OpenApiHandler {
+    /// Create a new handler from an API spec.
     pub fn new(spec: OpenApi) -> Self {
         OpenApiHandler { spec }
     }
 
+    /// Create a new route from this `OpenApiHandler`.
     pub fn into_route(self, path: impl AsRef<str>) -> Route {
         Route::new(Method::Get, path, self)
     }

--- a/rocket-okapi/src/handlers/redirect.rs
+++ b/rocket-okapi/src/handlers/redirect.rs
@@ -3,18 +3,21 @@ use rocket::http::Method;
 use rocket::response::Redirect;
 use rocket::{Data, Request, Route};
 
+/// A handler that instead of serving content always redirects to some specified direction.
 #[derive(Clone)]
 pub struct RedirectHandler {
     dest: &'static str,
 }
 
 impl RedirectHandler {
+    /// Create a new `RedirectHandler` to the specified route.
     pub fn to(dest: &'static str) -> Self {
         Self {
             dest: dest.trim_start_matches('/'),
         }
     }
 
+    /// Create a new `Route` from this `Handler`.
     pub fn into_route(self, path: impl AsRef<str>) -> Route {
         Route::new(Method::Get, path, self)
     }

--- a/rocket-okapi/src/lib.rs
+++ b/rocket-okapi/src/lib.rs
@@ -1,21 +1,100 @@
 #![feature(specialization)]
+#![forbid(missing_docs)]
+
+//! This projects serves to enable automatic rendering of `openapi.json` files, and provides
+//! facilities to also serve the documentation alonside your api.
+//!
+//! # Usage
+//! First, add the following lines to your `Cargo.toml`
+//! ```toml
+//! [dependencies]
+//! rocket_okapi = "0.3"
+//! schemars = "0.6"
+//! okapi = { version = "0.3", features = ["derive_json_schema"] }
+//! ```
+//! To add documentation to a set of endpoints, a couple of steps are required. The request and
+//! response types of the endpoint must implement `JsonSchema`. Secondly, the function must be
+//! marked with `#[openapi]`. After that, you can simply replace `routes!` with
+//! `routes_with_openapi!`. This will append an additional route to the resulting `Vec<Route>`,
+//! which contains the `openapi.json` file that is required by swagger. Now that we have the json
+//! file that we need, we can serve the swagger web interface at another endpoint, and we should be
+//! able to load the example in the browser!
+//! ### Example
+//! ```rust, no_run
+//! #![feature(decl_macro, proc_macro_hygiene)]
+//! 
+//! use rocket::get;
+//! use rocket_contrib::json::Json;
+//! use rocket_okapi::{openapi, routes_with_openapi, JsonSchema};
+//! use rocket_okapi::swagger_ui::{make_swagger_ui, SwaggerUIConfig};
+//! 
+//! #[derive(serde::Serialize, JsonSchema)]
+//! struct Response {
+//!     reply: String,
+//! }
+//! 
+//! #[openapi]
+//! #[get("/")]
+//! fn my_controller() -> Json<Response> {
+//!     Json(Response {
+//!         reply: "show me the docs!".to_string(),
+//!     })
+//! }
+//!
+//! fn get_docs() -> SwaggerUIConfig {
+//!     use rocket_okapi::swagger_ui::UrlObject;
+//! 
+//!     SwaggerUIConfig {
+//!         url: Some("/my_resource/openapi.json".to_string()),
+//!         urls: Some(vec![
+//!             UrlObject {
+//!                 name: "My Resource".to_string(),
+//!                 url: "/v1/company/openapi.json".to_string(),
+//!             },
+//!         ]),
+//!     }
+//! }
+//! 
+//! fn main() {
+//!     rocket::ignite()
+//!         .mount("/my_resource", routes_with_openapi![my_controller])
+//!         .mount("/swagger", make_swagger_ui(&get_docs()))
+//!         .launch();
+//! }
+//! ```
 
 mod error;
 
+/// Contains the `Generator` struct, which you can use to manually control the way a struct is 
+/// represented in the documentation.
 pub mod gen;
+/// Contains several `Rocket` `Handler`s, which are used for serving the json files and the swagger
+/// interface.
 pub mod handlers;
+/// This module contains several traits that correspond to the `Rocket` traits pertaining to request
+/// guards and responses
 pub mod request;
+/// Contains the trait `OpenApiResponder`, meaning that a response implementing this trait can be
+/// documented.
 pub mod response;
+/// Contains then `OpenApiSettings` struct, which can be used to customise the behaviour of a
+/// `Generator`.
 pub mod settings;
+/// Contains the functions and structs required to display the swagger web ui.
 pub mod swagger_ui;
+/// Assorted function that are used throughout the application.
 pub mod util;
 
 pub use error::*;
 pub use rocket_okapi_codegen::*;
 pub use schemars::JsonSchema;
 
+/// Contains information about an endpoint.
 pub struct OperationInfo {
+    /// The path of the endpoint
     pub path: String,
+    /// The HTTP Method of this endpoint.
     pub method: rocket::http::Method,
+    /// Contains information to be showed in the documentation about this endpoint.
     pub operation: okapi::openapi3::Operation,
 }

--- a/rocket-okapi/src/lib.rs
+++ b/rocket-okapi/src/lib.rs
@@ -46,12 +46,7 @@
 //! 
 //!     SwaggerUIConfig {
 //!         url: Some("/my_resource/openapi.json".to_string()),
-//!         urls: Some(vec![
-//!             UrlObject {
-//!                 name: "My Resource".to_string(),
-//!                 url: "/v1/company/openapi.json".to_string(),
-//!             },
-//!         ]),
+//!         urls: Some(vec![UrlObject::new("My Resource", "/v1/company/openapi.json")]),
 //!     }
 //! }
 //! 

--- a/rocket-okapi/src/request/mod.rs
+++ b/rocket-okapi/src/request/mod.rs
@@ -5,22 +5,42 @@ use super::gen::OpenApiGenerator;
 use super::Result;
 use okapi::openapi3::*;
 
+/// This trait means that the implementer can be used as a `FromData` request guard, and that this
+/// can also be documented.
 pub trait OpenApiFromData<'r>: rocket::data::FromData<'r> {
+    /// Return a `RequestBody` containing the information required to document the `FromData` for
+    /// implementer.
     fn request_body(gen: &mut OpenApiGenerator) -> Result<RequestBody>;
 }
 
+/// This trait means that the implementer can be used as a `FromParam` request guard, and that this
+/// can also be documented.
 pub trait OpenApiFromParam<'r>: rocket::request::FromParam<'r> {
+    /// Return a `RequestBody` containing the information required to document the `FromParam` for
+    /// implementer.
     fn path_parameter(gen: &mut OpenApiGenerator, name: String) -> Result<Parameter>;
 }
 
+/// This trait means that the implementer can be used as a `FromSegments` request guard, and that
+/// this can also be documented.
 pub trait OpenApiFromSegments<'r>: rocket::request::FromSegments<'r> {
+    /// Return a `RequestBody` containing the information required to document the `FromSegments`
+    /// for implementer.
     fn path_multi_parameter(gen: &mut OpenApiGenerator, name: String) -> Result<Parameter>;
 }
 
+/// This trait means that the implementer can be used as a `FromFormValue` request guard, and that
+/// this can also be documented.
 pub trait OpenApiFromFormValue<'r>: rocket::request::FromFormValue<'r> {
+    /// Return a `RequestBody` containing the information required to document the `FromFormValue`
+    /// for implementer.
     fn query_parameter(gen: &mut OpenApiGenerator, name: String) -> Result<Parameter>;
 }
 
+/// This trait means that the implementer can be used as a `FromQuery` request guard, and that this
+/// can also be documented.
 pub trait OpenApiFromQuery<'r>: rocket::request::FromQuery<'r> {
+    /// Return a `RequestBody` containing the information required to document the `FromQuery` for
+    /// implementer.
     fn query_multi_parameter(gen: &mut OpenApiGenerator, name: String) -> Result<Parameter>;
 }

--- a/rocket-okapi/src/response/mod.rs
+++ b/rocket-okapi/src/response/mod.rs
@@ -4,6 +4,10 @@ use super::gen::OpenApiGenerator;
 use super::Result;
 use okapi::openapi3::Responses;
 
+/// Implementing this trait means that any route returning the implementer can me marked with
+/// `#[openapi]`, and that the route can be documented.
 pub trait OpenApiResponder<'r>: rocket::response::Responder<'r> {
+    /// Create the responses type, which is a list of responses that can be rendered in
+    /// `openapi.json` format.
     fn responses(gen: &mut OpenApiGenerator) -> Result<Responses>;
 }

--- a/rocket-okapi/src/settings.rs
+++ b/rocket-okapi/src/settings.rs
@@ -1,8 +1,12 @@
 use schemars::gen::SchemaSettings;
 
+/// Settings which are used to customise the behaviour of the `Generator`.
 #[derive(Debug, PartialEq, Clone)]
 pub struct OpenApiSettings {
+    /// Allows configuring to which standard the api documentation must confirm.
     pub schema_settings: SchemaSettings,
+    /// The path to the json file that contains the API specification. Then default is
+    /// `openapi.json`.
     pub json_path: String,
 }
 
@@ -16,6 +20,7 @@ impl Default for OpenApiSettings {
 }
 
 impl OpenApiSettings {
+    /// Create a new instance of `OpenApiSettings`. Equivalent to calling `Default::default`.
     pub fn new() -> Self {
         OpenApiSettings {
             ..Default::default()

--- a/rocket-okapi/src/swagger_ui.rs
+++ b/rocket-okapi/src/swagger_ui.rs
@@ -36,6 +36,16 @@ pub struct UrlObject {
     pub url: String,
 }
 
+impl UrlObject {
+    /// Create a new `UrlObject` from the provided name and url.
+    pub fn new(name: &str, url: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            url: url.to_string(),
+        }
+    }
+}
+
 /// Transform the provided `SwaggerUIConfig` into a list of `Route`s that serve the swagger web ui.
 pub fn make_swagger_ui(config: &SwaggerUIConfig) -> impl Into<Vec<Route>> {
     let config_handler = ContentHandler::json(config);

--- a/rocket-okapi/src/swagger_ui.rs
+++ b/rocket-okapi/src/swagger_ui.rs
@@ -14,21 +14,29 @@ macro_rules! static_file {
     };
 }
 
+/// A struct containing information about where and how the `openapi.json` files are served.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SwaggerUIConfig {
+    /// The url to the default `openapi.json` file that is showed when the web ui is first opened.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    /// A list of named urls that contain all the `openapi.json` files that you want to display in
+    /// your web ui.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub urls: Option<Vec<UrlObject>>,
 }
 
+/// Contains a named url.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct UrlObject {
+    /// The name of the url.
     pub name: String,
+    /// The url itself.
     pub url: String,
 }
 
+/// Transform the provided `SwaggerUIConfig` into a list of `Route`s that serve the swagger web ui.
 pub fn make_swagger_ui(config: &SwaggerUIConfig) -> impl Into<Vec<Route>> {
     let config_handler = ContentHandler::json(config);
     vec![

--- a/rocket-okapi/src/util.rs
+++ b/rocket-okapi/src/util.rs
@@ -4,7 +4,9 @@ use okapi::Map;
 
 // FIXME this whole file is a huge mess...
 
-pub fn set_status_code(responses: &mut Responses, status: u16) -> Result<()> {
+/// Takes a `Responses` struct, and sets the status code to the status code provided for each
+/// response in the `Responses`.
+pub(crate) fn set_status_code(responses: &mut Responses, status: u16) -> Result<()> {
     let old_responses = std::mem::replace(&mut responses.responses, Map::new());
     let new_response = ensure_not_ref(ensure_status_code_exists(responses, status))?;
     for (_, mut response) in old_responses {
@@ -14,14 +16,16 @@ pub fn set_status_code(responses: &mut Responses, status: u16) -> Result<()> {
     Ok(())
 }
 
-pub fn ensure_status_code_exists(responses: &mut Responses, status: u16) -> &mut RefOr<Response> {
+/// Checks if the provided `status` code is in the `responses.responses` field. If it isn't, inserts
+/// it.
+pub(crate) fn ensure_status_code_exists(responses: &mut Responses, status: u16) -> &mut RefOr<Response> {
     responses
         .responses
         .entry(status.to_string())
         .or_insert_with(|| Response::default().into())
 }
 
-pub fn add_content_response(
+pub(crate) fn add_content_response(
     responses: &mut Responses,
     status: u16,
     content_type: impl ToString,
@@ -32,7 +36,7 @@ pub fn add_content_response(
     Ok(())
 }
 
-pub fn add_media_type(
+pub(crate) fn add_media_type(
     content: &mut Map<String, MediaType>,
     content_type: impl ToString,
     media: MediaType,
@@ -44,7 +48,7 @@ pub fn add_media_type(
         .or_insert(media);
 }
 
-pub fn set_content_type(
+pub(crate) fn set_content_type(
     responses: &mut Responses,
     content_type: impl ToString
 ) -> Result<()> {
@@ -62,7 +66,7 @@ pub fn set_content_type(
     Ok(())
 }
 
-pub fn add_schema_response(
+pub(crate) fn add_schema_response(
     responses: &mut Responses,
     status: u16,
     content_type: impl ToString,
@@ -75,7 +79,7 @@ pub fn add_schema_response(
     add_content_response(responses, status, content_type, media)
 }
 
-pub fn produce_any_responses(r1: Responses, r2: Responses) -> Result<Responses> {
+pub(crate) fn produce_any_responses(r1: Responses, r2: Responses) -> Result<Responses> {
     let mut result = Responses {
         default: r1.default.or(r2.default),
         responses: r1.responses,


### PR DESCRIPTION
To make it easier to use this project for people who want to document their API, it is convenient if the public API is fully documented. I've provided a best-effort, but I am by no means an expert on the internals of `rocket` or `schemars`. Some of the docs I have created might therefore be incorrect.

 I have added a lint that denies missing docs from being published, I don't know if this is too restrictive for the current status of the project, but it can always be removed.

I have also added the function `UrlObject::new`, which makes the example in `lib.rs` much simpler.