### PR TITLE
Lookup route handler parameters on identifier only

### DIFF
--- a/examples/json-web-api/src/main.rs
+++ b/examples/json-web-api/src/main.rs
@@ -45,6 +45,13 @@ fn create_user(user: Json<User>) -> Json<User> {
     user
 }
 
+#[openapi]
+#[post("/user_give_email", data = "<user>")]
+fn user_give_email(mut user: Json<User>) -> Json<User> {
+    user.email = Some("contrived@test.com".to_string());
+    user
+}
+
 #[openapi(skip)]
 #[get("/hidden")]
 fn hidden() -> Json<&'static str> {
@@ -55,7 +62,7 @@ fn main() {
     rocket::ignite()
         .mount(
             "/",
-            routes_with_openapi![get_all_users, get_user, create_user, hidden],
+            routes_with_openapi![get_all_users, get_user, create_user, user_give_email, hidden],
         )
         .mount(
             "/swagger-ui/",

--- a/examples/json-web-api/src/main.rs
+++ b/examples/json-web-api/src/main.rs
@@ -45,13 +45,6 @@ fn create_user(user: Json<User>) -> Json<User> {
     user
 }
 
-#[openapi]
-#[post("/user_give_email", data = "<user>")]
-fn user_give_email(mut user: Json<User>) -> Json<User> {
-    user.email = Some("contrived@test.com".to_string());
-    user
-}
-
 #[openapi(skip)]
 #[get("/hidden")]
 fn hidden() -> Json<&'static str> {
@@ -62,7 +55,7 @@ fn main() {
     rocket::ignite()
         .mount(
             "/",
-            routes_with_openapi![get_all_users, get_user, create_user, user_give_email, hidden],
+            routes_with_openapi![get_all_users, get_user, create_user, hidden],
         )
         .mount(
             "/swagger-ui/",

--- a/rocket-okapi-codegen/src/openapi_attr/mod.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/mod.rs
@@ -129,9 +129,12 @@ fn get_arg_types(args: impl Iterator<Item = FnArg>) -> Map<String, Type> {
     let mut result = Map::new();
     for arg in args {
         if let syn::FnArg::Typed(arg) = arg {
-            let name = arg.pat.into_token_stream().to_string();
-            let ty = *arg.ty;
-            result.insert(name, ty);
+            if let syn::Pat::Ident(ident) = *arg.pat {
+                // Use only identifier name as key, so lookups succeed even if argument is mutable
+                let name = ident.ident.into_token_stream().to_string();
+                let ty = *arg.ty;
+                result.insert(name, ty);
+            }
         }
     }
     result


### PR DESCRIPTION
This fixes issue #17 where mutable identifiers breaks the generated macro, because the `mut` keyword become part of the key in the map of identifier to type that is used to look up data and path parameters.

I included a new route in the example, to show that it works. It is very contrived, so maybe just remove it?

I have done nothing to improve error handling.