### PR TITLE
Adding Basic info to openapi file

### DIFF
--- a/rocket-okapi-codegen/src/routes_with_openapi/mod.rs
+++ b/rocket-okapi-codegen/src/routes_with_openapi/mod.rs
@@ -17,7 +17,30 @@ fn parse_inner(routes: TokenStream) -> Result<TokenStream2> {
             let settings = ::rocket_okapi::settings::OpenApiSettings::new();
             let mut gen = ::rocket_okapi::gen::OpenApiGenerator::new(settings.clone());
             #add_operations
-            let spec = gen.into_openapi();
+            let mut spec = gen.into_openapi();
+            let mut info = ::okapi::openapi3::Info {
+                title: env!("CARGO_PKG_NAME").to_owned(),
+                version: env!("CARGO_PKG_VERSION").to_owned(),
+                ..Default::default()
+            };
+            if !env!("CARGO_PKG_DESCRIPTION").is_empty() {
+                info.description = Some(env!("CARGO_PKG_DESCRIPTION").to_owned());
+            }
+            if !env!("CARGO_PKG_REPOSITORY").is_empty() {
+                info.contact = Some(::okapi::openapi3::Contact{
+                    name: Some("Repository".to_owned()),
+                    url: Some(env!("CARGO_PKG_REPOSITORY").to_owned()),
+                    ..Default::default()
+                });
+            }
+            if !env!("CARGO_PKG_HOMEPAGE").is_empty() {
+                info.contact = Some(::okapi::openapi3::Contact{
+                    name: Some("Homepage".to_owned()),
+                    url: Some(env!("CARGO_PKG_REPOSITORY").to_owned()),
+                    ..Default::default()
+                });
+            }
+            spec.info = info;
 
             let mut routes = ::rocket::routes![#paths];
             routes.push(::rocket_okapi::handlers::OpenApiHandler::new(spec).into_route(&settings.json_path));


### PR DESCRIPTION
I have added some info to the OpenAPI file.

This will use the `Cargo.toml` file of the `routes_with_openapi![..]` call is made.
This might not be ideal but at least there is some info now.
I have a different workspace for my API server and it uses that Cargo.toml file from the workspace instead of the main workspace, because the call is there. But can live with that for now.
Otherwise I might create some global statics to override the values.
I was first planning on adding it to `rocket_okapi/src/gen.rs: into_openapi()` but then it uses the Cargo.toml from rocket_okapi. 

For more info see: https://doc.rust-lang.org/cargo/reference/environment-variables.html