### PR TITLE
Add extra options to SwaggerUIConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ pub fn make_rocket() -> rocket::Rocket {
         .mount(
             "/swagger-ui/",
             make_swagger_ui(&SwaggerUIConfig {
-                url: Some("../openapi.json".to_owned()),
-                urls: None,
+                url: "../openapi.json".to_owned(),
+                ..Default::default()
             }),
         )
 }

--- a/examples/json-web-api/src/main.rs
+++ b/examples/json-web-api/src/main.rs
@@ -67,8 +67,8 @@ fn main() {
         .mount(
             "/swagger-ui/",
             make_swagger_ui(&SwaggerUIConfig {
-                url: Some("../openapi.json".to_owned()),
-                urls: None,
+                url: "../openapi.json".to_owned(),
+                ..Default::default()
             }),
         )
         .launch();

--- a/rocket-okapi/src/lib.rs
+++ b/rocket-okapi/src/lib.rs
@@ -45,8 +45,8 @@
 //!     use rocket_okapi::swagger_ui::UrlObject;
 //! 
 //!     SwaggerUIConfig {
-//!         url: Some("/my_resource/openapi.json".to_string()),
-//!         urls: Some(vec![UrlObject::new("My Resource", "/v1/company/openapi.json")]),
+//!         url: "/my_resource/openapi.json".to_string(),
+//!         urls: vec![UrlObject::new("My Resource", "/v1/company/openapi.json")],
 //!     }
 //! }
 //! 

--- a/rocket-okapi/src/lib.rs
+++ b/rocket-okapi/src/lib.rs
@@ -2,7 +2,7 @@
 #![forbid(missing_docs)]
 
 //! This projects serves to enable automatic rendering of `openapi.json` files, and provides
-//! facilities to also serve the documentation alonside your api.
+//! facilities to also serve the documentation alongside your api.
 //!
 //! # Usage
 //! First, add the following lines to your `Cargo.toml`

--- a/rocket-okapi/src/swagger_ui.rs
+++ b/rocket-okapi/src/swagger_ui.rs
@@ -54,7 +54,7 @@ fn is_zero(num: &u32) -> bool {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SwaggerUIConfig {
-    /// The url to a signle `openapi.json` file that is showed when the web ui is first opened.
+    /// The url to a single `openapi.json` file that is showed when the web ui is first opened.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub url: String,
     /// A list of named urls that contain all the `openapi.json` files that you want to display in

--- a/rocket-okapi/src/swagger_ui.rs
+++ b/rocket-okapi/src/swagger_ui.rs
@@ -14,17 +14,117 @@ macro_rules! static_file {
     };
 }
 
+/// Used to control the way models are displayed by default.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DefaultModelRendering {
+    /// Expand the `example` section.
+    Example,
+    /// Expand the `model` section.
+    Model,
+}
+
+/// Used to control the default expansion setting for the operations and tags.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DocExpansion {
+    /// Expands only the tags.
+    List,
+    /// Expands the tags and operations
+    Full,
+    /// Expands nothing
+    None,
+}
+
+/// Used to enable, disable and preconfigure filtering
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Filter {
+    /// Use this variant to enable or disable filtering.
+    Bool(bool),
+    /// Use this variant to enable filtering, and preconfigure a filter.
+    Str(String),
+}
+
+fn is_zero(num: &u32) -> bool {
+    *num == 0
+}
+
 /// A struct containing information about where and how the `openapi.json` files are served.
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SwaggerUIConfig {
-    /// The url to the default `openapi.json` file that is showed when the web ui is first opened.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    /// The url to a signle `openapi.json` file that is showed when the web ui is first opened.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub url: String,
     /// A list of named urls that contain all the `openapi.json` files that you want to display in
-    /// your web ui.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub urls: Option<Vec<UrlObject>>,
+    /// your web ui. If this field is populated, the `url` field is not used.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub urls: Vec<UrlObject>,
+    
+    // display options:
+    /// If set to true, enables deep linking for tags and operations. See the
+    /// [Deep Linking documentation](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/deep-linking.md)
+    /// for more information.
+    /// Default: `false`. 
+    pub deep_linking: bool,
+    /// Controls the display of operationId in operations list.
+    /// Default: `false`. 
+    pub display_operation_id: bool,
+    /// The default expansion depth for models (set to -1 completely hide the models).
+    /// Default: `1`.
+    pub default_models_expand_depth: i32,
+    /// The default expansion depth for the model on the model-example section.
+    /// Default: `1`.
+    pub default_model_expand_depth: i32,
+    /// Controls how the model is shown when the API is first rendered. (The user can always switch
+    /// the rendering for a given model by clicking the 'Model' and 'Example Value' links.)
+    /// Default: `DefaultModelRendering::Example`.
+    pub default_model_rendering: DefaultModelRendering,
+    /// Controls the display of the request duration (in milliseconds) for "Try it out" requests.
+    /// Default: `false`.
+    pub display_request_duration: bool,
+    /// Controls the default expansion setting for the operations and tags.
+    /// Default: `DocExpansion::List`.
+    pub doc_expansion: DocExpansion,
+    /// If set, enables filtering. The top bar will show an edit box that you can use to filter the
+    /// tagged operations that are shown. Filtering is case sensitive matching the filter expression
+    /// anywhere inside the tag.
+    /// Default: `Filter(false)`.
+    pub filter: Filter,
+    /// If set, limits the number of tagged operations displayed to at most this many. The default
+    /// is to show all operations.
+    /// Default: `None` (displays all tagged operations).
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub max_displayed_tags: u32,
+    /// Controls the display of vendor extension (`x-`) fields and values for Operations,
+    /// Parameters, and Schema.
+    /// Default: `false`.
+    pub show_extensions: bool,
+    /// Controls the display of extensions (`pattern`, `maxLength`, `minLength`, `maximum`,
+    /// `minimum`) fields and values for Parameters.
+    /// Default: `false`.
+    pub show_common_extensions: bool,
+}
+
+impl Default for SwaggerUIConfig {
+    fn default() -> Self {
+        Self {
+            url: String::new(),
+            urls: vec![],
+            deep_linking: false,
+            display_operation_id: false,
+            default_model_expand_depth: 1,
+            default_model_rendering: DefaultModelRendering::Example,
+            default_models_expand_depth: 1,
+            display_request_duration: false,
+            doc_expansion: DocExpansion::List,
+            filter: Filter::Bool(false),
+            max_displayed_tags: 0,
+            show_extensions: false,
+            show_common_extensions: false,
+        }
+    }
 }
 
 /// Contains a named url.


### PR DESCRIPTION
This pull request adds all documented items from the [display](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#display) category to the fields of the struct `SwaggerUIConfig`. There are a couple of issues still, namely:
* turning on any of the parameters `filter`, `show_extensions`, `show_common_extensions` does nothing. I don't know if this is me misinterpreting the documentation, if the version of the front end doesn't like these options or if it is something else.
* turning on the parameter `max_displayed_tags` seems to only alter the spacing of the models (???)

I have also changed the two original fields in `SwaggerUIConfig` from `Option<T>` to `T`, and configured the `Default` to be the same as the default in the swagger documentation. This means that
```rust
let conf = SwaggerUIConfig {
    urls: Some(vec![myroute]),
    url: Some("openapi.json".to_string()),
    ..Default::default()
}
```
can be replaced by
```rust
let conf = SwaggerUIConfig {
    urls: vec![myroute],
    url: "openapi.json".to_string(),
    ..Default::default()
}
```
which feels like a more convenient public interface. I hope this is a welcome change!