### PR TITLE
Adding support for Query parameters in url.

### DIFF
--- a/examples/json-web-api/src/main.rs
+++ b/examples/json-web-api/src/main.rs
@@ -45,6 +45,19 @@ fn get_user(id: u64) -> Option<Json<User>> {
     }))
 }
 
+/// # Get user by name
+///
+/// Returns a single user by username.
+#[openapi]
+#[get("/user_example?<user_id>&<name>&<email>")]
+fn get_user_by_name(user_id: u64, name: String, email: Option<String>) -> Option<Json<User>> {
+    Some(Json(User {
+        user_id,
+        username: name,
+        email,
+    }))
+}
+
 /// # Create user
 #[openapi]
 #[post("/user", data = "<user>")]
@@ -62,7 +75,7 @@ fn main() {
     rocket::ignite()
         .mount(
             "/",
-            routes_with_openapi![get_all_users, get_user, create_user, hidden],
+            routes_with_openapi![get_all_users, get_user, get_user_by_name, create_user, hidden],
         )
         .mount(
             "/swagger-ui/",

--- a/examples/json-web-api/src/main.rs
+++ b/examples/json-web-api/src/main.rs
@@ -5,11 +5,11 @@ extern crate rocket;
 #[macro_use]
 extern crate rocket_okapi;
 
+use rocket::request::{Form, FromForm};
 use rocket_contrib::json::Json;
 use rocket_okapi::swagger_ui::*;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use rocket::request::{FromForm, Form};
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]

--- a/examples/json-web-api/src/main.rs
+++ b/examples/json-web-api/src/main.rs
@@ -9,6 +9,7 @@ use rocket_contrib::json::Json;
 use rocket_okapi::swagger_ui::*;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use rocket::request::{FromForm, Form};
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -71,11 +72,34 @@ fn hidden() -> Json<&'static str> {
     Json("Hidden from swagger!")
 }
 
+#[derive(Serialize, Deserialize, JsonSchema, FromForm)]
+struct Post {
+    post_id: u64,
+    title: String,
+    summary: Option<String>,
+}
+
+/// # Create post using query params
+///
+/// Returns the created post.
+#[openapi]
+#[get("/post_by_query?<post..>")]
+fn create_post_by_query(post: Form<Post>) -> Option<Json<Post>> {
+    Some(Json(post.into_inner()))
+}
+
 fn main() {
     rocket::ignite()
         .mount(
             "/",
-            routes_with_openapi![get_all_users, get_user, get_user_by_name, create_user, hidden],
+            routes_with_openapi![
+                get_all_users,
+                get_user,
+                get_user_by_name,
+                create_user,
+                hidden,
+                create_post_by_query,
+            ],
         )
         .mount(
             "/swagger-ui/",

--- a/examples/json-web-api/src/main.rs
+++ b/examples/json-web-api/src/main.rs
@@ -74,8 +74,11 @@ fn hidden() -> Json<&'static str> {
 
 #[derive(Serialize, Deserialize, JsonSchema, FromForm)]
 struct Post {
+    /// The unique identifier for the post.
     post_id: u64,
+    /// The title of the post.
     title: String,
+    /// A short summary of the post.
     summary: Option<String>,
 }
 

--- a/rocket-okapi-codegen/src/openapi_attr/mod.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/mod.rs
@@ -83,6 +83,18 @@ fn create_route_operation_fn(route_fn: ItemFn, route: route_attr::Route) -> Toke
             <#ty as ::rocket_okapi::request::OpenApiFromParam>::path_parameter(gen, #arg.to_owned())?.into()
         })
     }
+    for arg in route.query_params() {
+        let ty = match arg_types.get(arg) {
+            Some(ty) => ty,
+            None => return quote! {
+                compile_error!(concat!("Could not find argument ", #arg, " matching query param."))
+            }
+            .into(),
+        };
+        params.push(quote! {
+            <#ty as ::rocket_okapi::request::OpenApiFromParam>::query_parameter(gen, #arg.to_owned(), true)?.into()
+        })
+    }
 
     let fn_name = get_add_operation_fn_name(&route_fn.sig.ident);
     let path = route.origin.path().replace("<", "{").replace(">", "}");

--- a/rocket-okapi-codegen/src/openapi_attr/mod.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/mod.rs
@@ -71,28 +71,41 @@ fn create_route_operation_fn(route_fn: ItemFn, route: route_attr::Route) -> Toke
     };
 
     let mut params = Vec::new();
+    // Path parameters: `/<id>/<name>`
     for arg in route.path_params() {
         let ty = match arg_types.get(arg) {
             Some(ty) => ty,
             None => return quote! {
                 compile_error!(concat!("Could not find argument ", #arg, " matching path param."))
-            }
-            .into(),
+            }.into(),
         };
         params.push(quote! {
             <#ty as ::rocket_okapi::request::OpenApiFromParam>::path_parameter(gen, #arg.to_owned())?.into()
         })
     }
+    // Query parameters: `/?<id>&<name>`
     for arg in route.query_params() {
         let ty = match arg_types.get(arg) {
             Some(ty) => ty,
             None => return quote! {
                 compile_error!(concat!("Could not find argument ", #arg, " matching query param."))
-            }
-            .into(),
+            }.into(),
         };
         params.push(quote! {
-            <#ty as ::rocket_okapi::request::OpenApiFromParam>::query_parameter(gen, #arg.to_owned(), true)?.into()
+            <#ty as ::rocket_okapi::request::OpenApiFromFormValue>::query_parameter(gen, #arg.to_owned(), true)?.into()
+        })
+    }
+    let mut params_nested_list = Vec::new();
+    // Multi Query parameters: `/?<param..>`
+    for arg in route.query_multi_params() {
+        let ty = match arg_types.get(arg) {
+            Some(ty) => ty,
+            None => return quote! {
+                compile_error!(concat!("Could not find argument ", #arg, " matching query multi param."))
+            }.into(),
+        };
+        params_nested_list.push(quote! {
+            <#ty as ::rocket_okapi::request::OpenApiFromQuery>::query_multi_parameter(gen, #arg.to_owned(), true)?.into()
         })
     }
 
@@ -116,7 +129,15 @@ fn create_route_operation_fn(route_fn: ItemFn, route: route_attr::Route) -> Toke
         ) -> ::rocket_okapi::Result<()> {
             let responses = <#return_type as ::rocket_okapi::response::OpenApiResponder>::responses(gen)?;
             let request_body = #request_body;
-            let parameters = vec![#(#params),*];
+            let mut parameters: Vec<::okapi::openapi3::RefOr<::okapi::openapi3::Parameter>> = vec![#(#params),*];
+            // add nested lists
+            let parameters_nested_list: Vec<Vec<::okapi::openapi3::Parameter>> = vec![#(#params_nested_list),*];
+            for inner_list in parameters_nested_list{
+                for item in inner_list{
+                    // convert every item from `Parameter` to `RefOr<Parameter>``
+                    parameters.push(item.into());
+                }
+            }
             gen.add_operation(::rocket_okapi::OperationInfo {
                 path: #path.to_owned(),
                 method: ::rocket::http::Method::#method,

--- a/rocket-okapi-codegen/src/openapi_attr/mod.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/mod.rs
@@ -77,7 +77,8 @@ fn create_route_operation_fn(route_fn: ItemFn, route: route_attr::Route) -> Toke
             Some(ty) => ty,
             None => return quote! {
                 compile_error!(concat!("Could not find argument ", #arg, " matching path param."));
-            }.into(),
+            }
+            .into(),
         };
         params.push(quote! {
             <#ty as ::rocket_okapi::request::OpenApiFromParam>::path_parameter(gen, #arg.to_owned())?.into()
@@ -89,7 +90,8 @@ fn create_route_operation_fn(route_fn: ItemFn, route: route_attr::Route) -> Toke
             Some(ty) => ty,
             None => return quote! {
                 compile_error!(concat!("Could not find argument ", #arg, " matching query param."));
-            }.into(),
+            }
+            .into(),
         };
         params.push(quote! {
             <#ty as ::rocket_okapi::request::OpenApiFromFormValue>::query_parameter(gen, #arg.to_owned(), true)?.into()

--- a/rocket-okapi-codegen/src/openapi_attr/mod.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/mod.rs
@@ -76,7 +76,7 @@ fn create_route_operation_fn(route_fn: ItemFn, route: route_attr::Route) -> Toke
         let ty = match arg_types.get(arg) {
             Some(ty) => ty,
             None => return quote! {
-                compile_error!(concat!("Could not find argument ", #arg, " matching path param."))
+                compile_error!(concat!("Could not find argument ", #arg, " matching path param."));
             }.into(),
         };
         params.push(quote! {
@@ -88,7 +88,7 @@ fn create_route_operation_fn(route_fn: ItemFn, route: route_attr::Route) -> Toke
         let ty = match arg_types.get(arg) {
             Some(ty) => ty,
             None => return quote! {
-                compile_error!(concat!("Could not find argument ", #arg, " matching query param."))
+                compile_error!(concat!("Could not find argument ", #arg, " matching query param."));
             }.into(),
         };
         params.push(quote! {
@@ -101,7 +101,7 @@ fn create_route_operation_fn(route_fn: ItemFn, route: route_attr::Route) -> Toke
         let ty = match arg_types.get(arg) {
             Some(ty) => ty,
             None => return quote! {
-                compile_error!(concat!("Could not find argument ", #arg, " matching query multi param."))
+                compile_error!(concat!("Could not find argument ", #arg, " matching query multi param."));
             }.into(),
         };
         params_nested_list.push(quote! {

--- a/rocket-okapi-codegen/src/openapi_attr/route_attr.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/route_attr.rs
@@ -26,30 +26,36 @@ impl Route {
 
     pub fn query_params(&self) -> impl Iterator<Item = &str> {
         let mut query_params: Vec<&str> = vec![];
-        if let Some(query) = self.origin.query(){
+        if let Some(query) = self.origin.query() {
             query_params = query.split('&').collect();
-            query_params = query_params.into_iter().filter_map(|s| {
-                if s.starts_with('<') && s.ends_with('>') && !s.ends_with("..>") {
-                    Some(&s[1..s.len() - 1])
-                } else {
-                    None
-                }
-            }).collect();
+            query_params = query_params
+                .into_iter()
+                .filter_map(|s| {
+                    if s.starts_with('<') && s.ends_with('>') && !s.ends_with("..>") {
+                        Some(&s[1..s.len() - 1])
+                    } else {
+                        None
+                    }
+                })
+                .collect();
         }
         query_params.into_iter()
     }
 
     pub fn query_multi_params(&self) -> impl Iterator<Item = &str> {
         let mut query_params: Vec<&str> = vec![];
-        if let Some(query) = self.origin.query(){
+        if let Some(query) = self.origin.query() {
             query_params = query.split('&').collect();
-            query_params = query_params.into_iter().filter_map(|s| {
-                if s.starts_with('<') && s.ends_with("..>"){
-                    Some(&s[1..s.len() - 3])
-                } else {
-                    None
-                }
-            }).collect();
+            query_params = query_params
+                .into_iter()
+                .filter_map(|s| {
+                    if s.starts_with('<') && s.ends_with("..>") {
+                        Some(&s[1..s.len() - 3])
+                    } else {
+                        None
+                    }
+                })
+                .collect();
         }
         query_params.into_iter()
     }

--- a/rocket-okapi-codegen/src/openapi_attr/route_attr.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/route_attr.rs
@@ -23,6 +23,21 @@ impl Route {
             }
         })
     }
+    
+    pub fn query_params(&self) -> impl Iterator<Item = &str> {
+        let mut query_params: Vec<&str> = vec![];
+        if let Some(query) = self.origin.query(){
+            query_params = query.split('&').collect();
+            query_params = query_params.into_iter().filter_map(|s| {
+                if s.starts_with('<') && s.ends_with('>') && !s.ends_with("..>") {
+                    Some(&s[1..s.len() - 1])
+                } else {
+                    None
+                }
+            }).collect();
+        }
+        query_params.into_iter()
+    }
 
     pub fn _path_multi_param(&self) -> Option<&str> {
         self.origin.segments().find_map(|s| {

--- a/rocket-okapi-codegen/src/openapi_attr/route_attr.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/route_attr.rs
@@ -23,7 +23,7 @@ impl Route {
             }
         })
     }
-    
+
     pub fn query_params(&self) -> impl Iterator<Item = &str> {
         let mut query_params: Vec<&str> = vec![];
         if let Some(query) = self.origin.query(){
@@ -31,6 +31,21 @@ impl Route {
             query_params = query_params.into_iter().filter_map(|s| {
                 if s.starts_with('<') && s.ends_with('>') && !s.ends_with("..>") {
                     Some(&s[1..s.len() - 1])
+                } else {
+                    None
+                }
+            }).collect();
+        }
+        query_params.into_iter()
+    }
+
+    pub fn query_multi_params(&self) -> impl Iterator<Item = &str> {
+        let mut query_params: Vec<&str> = vec![];
+        if let Some(query) = self.origin.query(){
+            query_params = query.split('&').collect();
+            query_params = query_params.into_iter().filter_map(|s| {
+                if s.starts_with('<') && s.ends_with("..>"){
+                    Some(&s[1..s.len() - 3])
                 } else {
                     None
                 }

--- a/rocket-okapi/src/gen.rs
+++ b/rocket-okapi/src/gen.rs
@@ -55,6 +55,20 @@ impl OpenApiGenerator {
         &self.schema_generator
     }
 
+    /// Return the component definition of an object using its reference.
+    /// Example reference: "#/components/schemas/Data" Where `Data` is the name of the struct
+    pub fn json_definition(&mut self, reference: String) -> Option<schemars::schema::Schema>{
+        let definition = self.schema_generator.definitions();
+        // get the list item name from the reference
+        let schema_name: String = reference.rsplitn(2, '/').collect::<Vec<&str>>()[0].to_owned();
+        for (key, component) in definition{
+            if key == &schema_name{
+                return Some(component.clone());
+            }
+        }
+        None
+    }
+
     /// Generate an `OpenApi` specification for all added operations.
     pub fn into_openapi(self) -> OpenApi {
         OpenApi {

--- a/rocket-okapi/src/gen.rs
+++ b/rocket-okapi/src/gen.rs
@@ -55,18 +55,9 @@ impl OpenApiGenerator {
         &self.schema_generator
     }
 
-    /// Return the component definition of an object using its reference.
-    /// Example reference: "#/components/schemas/Data" Where `Data` is the name of the struct
-    pub fn json_definition(&mut self, reference: String) -> Option<schemars::schema::Schema>{
-        let definition = self.schema_generator.definitions();
-        // get the list item name from the reference
-        let schema_name: String = reference.rsplitn(2, '/').collect::<Vec<&str>>()[0].to_owned();
-        for (key, component) in definition{
-            if key == &schema_name{
-                return Some(component.clone());
-            }
-        }
-        None
+    /// Return the component definition/schema of an object without any references.
+    pub fn json_schema_no_ref<T: ?Sized + JsonSchema>(&mut self) -> SchemaObject {
+        <T>::json_schema(&mut self.schema_generator).into()
     }
 
     /// Generate an `OpenApi` specification for all added operations.

--- a/rocket-okapi/src/lib.rs
+++ b/rocket-okapi/src/lib.rs
@@ -47,6 +47,7 @@
 //!     SwaggerUIConfig {
 //!         url: "/my_resource/openapi.json".to_string(),
 //!         urls: vec![UrlObject::new("My Resource", "/v1/company/openapi.json")],
+//!         ..Default::default()
 //!     }
 //! }
 //!

--- a/rocket-okapi/src/request/from_param_impls.rs
+++ b/rocket-okapi/src/request/from_param_impls.rs
@@ -28,26 +28,6 @@ macro_rules! impl_from_param {
                     extensions: Default::default(),
                 })
             }
-            fn query_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result {
-                let schema = gen.json_schema::<$ty>();
-                Ok(Parameter {
-                    name,
-                    location: "query".to_owned(),
-                    description: None,
-                    required,
-                    deprecated: false,
-                    allow_empty_value: false,
-                    value: ParameterValue::Schema {
-                        style: None,
-                        explode: None,
-                        allow_reserved: false,
-                        schema,
-                        example: None,
-                        examples: None,
-                    },
-                    extensions: Default::default(),
-                })
-            }
         }
     };
 }
@@ -76,16 +56,10 @@ impl<'r, T: OpenApiFromParam<'r>> OpenApiFromParam<'r> for StdResult<T, T::Error
     fn path_parameter(gen: &mut OpenApiGenerator, name: String) -> Result {
         T::path_parameter(gen, name)
     }
-    fn query_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result {
-        T::query_parameter(gen, name, required)
-    }
 }
 
 impl<'r, T: OpenApiFromParam<'r>> OpenApiFromParam<'r> for Option<T> {
     fn path_parameter(gen: &mut OpenApiGenerator, name: String) -> Result {
         T::path_parameter(gen, name)
-    }
-    fn query_parameter(gen: &mut OpenApiGenerator, name: String, _required: bool) -> Result {
-        T::query_parameter(gen, name, false)
     }
 }

--- a/rocket-okapi/src/request/from_param_impls.rs
+++ b/rocket-okapi/src/request/from_param_impls.rs
@@ -28,6 +28,26 @@ macro_rules! impl_from_param {
                     extensions: Default::default(),
                 })
             }
+            fn query_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result {
+                let schema = gen.json_schema::<$ty>();
+                Ok(Parameter {
+                    name,
+                    location: "query".to_owned(),
+                    description: None,
+                    required,
+                    deprecated: false,
+                    allow_empty_value: false,
+                    value: ParameterValue::Schema {
+                        style: None,
+                        explode: None,
+                        allow_reserved: false,
+                        schema,
+                        example: None,
+                        examples: None,
+                    },
+                    extensions: Default::default(),
+                })
+            }
         }
     };
 }
@@ -56,10 +76,16 @@ impl<'r, T: OpenApiFromParam<'r>> OpenApiFromParam<'r> for StdResult<T, T::Error
     fn path_parameter(gen: &mut OpenApiGenerator, name: String) -> Result {
         T::path_parameter(gen, name)
     }
+    fn query_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result {
+        T::query_parameter(gen, name, required)
+    }
 }
 
 impl<'r, T: OpenApiFromParam<'r>> OpenApiFromParam<'r> for Option<T> {
     fn path_parameter(gen: &mut OpenApiGenerator, name: String) -> Result {
         T::path_parameter(gen, name)
+    }
+    fn query_parameter(gen: &mut OpenApiGenerator, name: String, _required: bool) -> Result {
+        T::query_parameter(gen, name, false)
     }
 }

--- a/rocket-okapi/src/request/from_query_multi_param_impls.rs
+++ b/rocket-okapi/src/request/from_query_multi_param_impls.rs
@@ -52,7 +52,6 @@ where
     T: JsonSchema,
 {
     let schema = gen.json_schema_no_ref::<T>();
-    println!("Schema: {:#?}", schema);
     // Get a list of properties from the structure.
     let mut properties: schemars::Map<String, Schema> = schemars::Map::new();
     if let Some(object) = schema.object {

--- a/rocket-okapi/src/request/from_query_multi_param_impls.rs
+++ b/rocket-okapi/src/request/from_query_multi_param_impls.rs
@@ -1,0 +1,153 @@
+use super::OpenApiFromQuery;
+use crate::gen::OpenApiGenerator;
+use okapi::openapi3::*;
+use std::result::Result as StdResult;
+use schemars::JsonSchema;
+use schemars::schema::{Schema, ObjectValidation, SchemaObject};
+use std::collections::BTreeMap;
+
+type Result = crate::Result<Vec<Parameter>>;
+
+/// Given an object that implements the `JsonSchema` generate all the `Parameter`
+/// that are used to create documentation.
+/// Use when manualy implementing a
+/// [Query Guard](https://docs.rs/rocket/latest/rocket/request/trait.FromQuery.html).
+/// Example:
+/// ```
+/// use rocket::request::{Query, FromQuery};
+/// use serde::{Serialize, Deserialize};
+/// use schemars::JsonSchema;
+/// use rocket_okapi::{
+///     gen::OpenApiGenerator,
+///     request::OpenApiFromQuery,
+///     request::get_nested_query_parameters
+/// };
+///
+/// #[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+/// pub struct ApiPagination{
+///     page: Option<u32>,
+///     per_page: Option<u32>,
+/// }
+///
+/// impl<'q> FromQuery<'q> for ApiPagination {
+///     type Error = String;// Some kind of error
+///
+///     fn from_query(_query: Query<'q>) -> Result<Self, Self::Error> {
+///         Ok(ApiPagination::default())
+///     }
+/// }
+///
+/// impl<'r> OpenApiFromQuery<'r> for ApiPagination {
+///     fn query_multi_parameter(gen: &mut OpenApiGenerator, name: String, required: bool)
+///     -> rocket_okapi::Result<Vec<okapi::openapi3::Parameter>> {
+///         Ok(get_nested_query_parameters::<ApiPagination>(gen, name, required))
+///     }
+/// }
+/// ```
+pub fn get_nested_query_parameters<'r, T>(gen: &mut OpenApiGenerator, name: String, required: bool)
+-> Vec<Parameter> where
+    T: JsonSchema{
+    let schema = gen.json_schema::<T>();
+    let mut referenced_schema: Option<Schema> = None;
+    if let Some(reference) = &schema.reference{
+        referenced_schema = gen.json_definition(reference.clone());
+    }
+    if let Some(schema) = referenced_schema{
+        // Get a list of properties from the structure.
+        let mut properties: BTreeMap<String, Schema> = BTreeMap::new();
+        match schema {
+            Schema::Object(schema) => {
+                if let Some(object) = schema.object{
+                    let object: &'r mut ObjectValidation = Box::leak(object);
+                    properties = object.properties.clone();
+                }
+            }
+            _ => {},
+        }
+
+        // Create all the `Parameter` for every property
+        let mut parameter_list: Vec<Parameter> = Vec::new();
+        for (key, property) in properties{
+            let prop_schema = match property {
+                Schema::Object(x) => x,
+                _ => SchemaObject::default(),
+            };
+            let mut parameter_required = required;
+            // Check if parameter is optional (only is not already optional)
+            if parameter_required {
+                for (key,value) in &prop_schema.extensions{
+                    if key == "nullable" {
+                        if let Some(nullable) = value.as_bool(){
+                            parameter_required = !nullable;
+                        }
+                    }
+                }
+            }
+            parameter_list.push(Parameter {
+                name: key,
+                location: "query".to_owned(),
+                description: None,
+                required: parameter_required,
+                deprecated: false,
+                allow_empty_value: false,
+                value: ParameterValue::Schema {
+                    style: None,
+                    explode: None,
+                    allow_reserved: false,
+                    schema: prop_schema,
+                    example: None,
+                    examples: None,
+                },
+                extensions: Default::default(),
+            });
+        }
+        return parameter_list;
+    }
+    vec![Parameter {
+        name,
+        location: "query".to_owned(),
+        description: None,
+        required,
+        deprecated: false,
+        allow_empty_value: false,
+        value: ParameterValue::Schema {
+            style: None,
+            explode: None,
+            allow_reserved: false,
+            schema,
+            example: None,
+            examples: None,
+        },
+        extensions: Default::default(),
+    }]
+}
+
+impl<'r, T: OpenApiFromQuery<'r>> OpenApiFromQuery<'r> for StdResult<T, T::Error> {
+    fn query_multi_parameter(gen: &mut OpenApiGenerator, name: String, _required: bool) -> Result {
+        T::query_multi_parameter(gen, name, false)
+    }
+}
+
+impl<'r, T: OpenApiFromQuery<'r>> OpenApiFromQuery<'r> for Option<T> {
+    fn query_multi_parameter(gen: &mut OpenApiGenerator, name: String, _required: bool) -> Result {
+        T::query_multi_parameter(gen, name, false)
+    }
+}
+
+// All fields are required.
+// Does not allow extra fields.
+impl<'r, T> OpenApiFromQuery<'r> for rocket::request::Form<T> where
+    T: rocket::request::FromForm<'r> + JsonSchema{
+    fn query_multi_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result {
+        Ok(get_nested_query_parameters::<T>(gen, name, required))
+    }
+}
+
+// All fields are required.
+// Does allow extra fields. (automatically discards extra fields without error)
+impl<'r, T> OpenApiFromQuery<'r> for rocket::request::LenientForm<T> where
+    T: rocket::request::FromForm<'r> + JsonSchema{
+    fn query_multi_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result {
+        Ok(get_nested_query_parameters::<T>(gen, name, required))
+    }
+}

--- a/rocket-okapi/src/request/from_query_multi_param_impls.rs
+++ b/rocket-okapi/src/request/from_query_multi_param_impls.rs
@@ -75,10 +75,14 @@ where
                 }
             }
         }
+        let description = prop_schema
+            .metadata
+            .as_ref()
+            .and_then(|m| m.description.clone());
         parameter_list.push(Parameter {
             name: key,
             location: "query".to_owned(),
-            description: None,
+            description,
             required: parameter_required,
             deprecated: false,
             allow_empty_value: false,

--- a/rocket-okapi/src/request/from_query_param_impls.rs
+++ b/rocket-okapi/src/request/from_query_param_impls.rs
@@ -1,0 +1,66 @@
+use super::OpenApiFromFormValue;
+use crate::gen::OpenApiGenerator;
+use okapi::openapi3::*;
+use std::result::Result as StdResult;
+
+type Result = crate::Result<Parameter>;
+
+macro_rules! impl_from_query_param {
+    ($ty: path) => {
+        impl<'r> OpenApiFromFormValue<'r> for $ty {
+            fn query_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result {
+                let schema = gen.json_schema::<$ty>();
+                Ok(Parameter {
+                    name,
+                    location: "query".to_owned(),
+                    description: None,
+                    required,
+                    deprecated: false,
+                    allow_empty_value: false,
+                    value: ParameterValue::Schema {
+                        style: None,
+                        explode: None,
+                        allow_reserved: false,
+                        schema,
+                        example: None,
+                        examples: None,
+                    },
+                    extensions: Default::default(),
+                })
+            }
+        }
+    };
+}
+
+impl_from_query_param!(f32);
+impl_from_query_param!(f64);
+impl_from_query_param!(isize);
+impl_from_query_param!(i8);
+impl_from_query_param!(i16);
+impl_from_query_param!(i32);
+impl_from_query_param!(i64);
+impl_from_query_param!(i128);
+impl_from_query_param!(usize);
+impl_from_query_param!(u8);
+impl_from_query_param!(u16);
+impl_from_query_param!(u32);
+impl_from_query_param!(u64);
+impl_from_query_param!(u128);
+impl_from_query_param!(bool);
+impl_from_query_param!(String);
+// Cow<> does not implement FromFormValue
+// impl_from_query_param!(std::borrow::Cow<'r, str>);
+
+// OpenAPI specification does not support optional path params, so we leave `required` as true,
+// even for Options and Results.
+impl<'r, T: OpenApiFromFormValue<'r>> OpenApiFromFormValue<'r> for StdResult<T, T::Error> {
+    fn query_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result {
+        T::query_parameter(gen, name, required)
+    }
+}
+
+impl<'r, T: OpenApiFromFormValue<'r>> OpenApiFromFormValue<'r> for Option<T> {
+    fn query_parameter(gen: &mut OpenApiGenerator, name: String, _required: bool) -> Result {
+        T::query_parameter(gen, name, false)
+    }
+}

--- a/rocket-okapi/src/request/mod.rs
+++ b/rocket-okapi/src/request/mod.rs
@@ -1,9 +1,15 @@
 mod from_data_impls;
 mod from_param_impls;
+mod from_query_param_impls;
+mod from_query_multi_param_impls;
 
 use super::gen::OpenApiGenerator;
 use super::Result;
 use okapi::openapi3::*;
+
+/// Expose this to the public to be use when manualy implementing a
+/// [Query Guard](https://docs.rs/rocket/latest/rocket/request/trait.FromQuery.html).
+pub use from_query_multi_param_impls::get_nested_query_parameters;
 
 /// This trait means that the implementer can be used as a `FromData` request guard, and that this
 /// can also be documented.
@@ -19,9 +25,6 @@ pub trait OpenApiFromParam<'r>: rocket::request::FromParam<'r> {
     /// Return a `RequestBody` containing the information required to document the `FromParam` for
     /// implementer. Path paremeters.
     fn path_parameter(gen: &mut OpenApiGenerator, name: String) -> Result<Parameter>;
-    /// Return a `RequestBody` containing the information required to document the `FromParam` for
-    /// implementer. Query paremeters.
-    fn query_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result<Parameter>;
 }
 
 /// This trait means that the implementer can be used as a `FromSegments` request guard, and that
@@ -37,7 +40,7 @@ pub trait OpenApiFromSegments<'r>: rocket::request::FromSegments<'r> {
 pub trait OpenApiFromFormValue<'r>: rocket::request::FromFormValue<'r> {
     /// Return a `RequestBody` containing the information required to document the `FromFormValue`
     /// for implementer.
-    fn query_parameter(gen: &mut OpenApiGenerator, name: String) -> Result<Parameter>;
+    fn query_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result<Parameter>;
 }
 
 /// This trait means that the implementer can be used as a `FromQuery` request guard, and that this
@@ -45,5 +48,5 @@ pub trait OpenApiFromFormValue<'r>: rocket::request::FromFormValue<'r> {
 pub trait OpenApiFromQuery<'r>: rocket::request::FromQuery<'r> {
     /// Return a `RequestBody` containing the information required to document the `FromQuery` for
     /// implementer.
-    fn query_multi_parameter(gen: &mut OpenApiGenerator, name: String) -> Result<Parameter>;
+    fn query_multi_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result<Vec<Parameter>>;
 }

--- a/rocket-okapi/src/request/mod.rs
+++ b/rocket-okapi/src/request/mod.rs
@@ -17,8 +17,11 @@ pub trait OpenApiFromData<'r>: rocket::data::FromData<'r> {
 /// can also be documented.
 pub trait OpenApiFromParam<'r>: rocket::request::FromParam<'r> {
     /// Return a `RequestBody` containing the information required to document the `FromParam` for
-    /// implementer.
+    /// implementer. Path paremeters.
     fn path_parameter(gen: &mut OpenApiGenerator, name: String) -> Result<Parameter>;
+    /// Return a `RequestBody` containing the information required to document the `FromParam` for
+    /// implementer. Query paremeters.
+    fn query_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result<Parameter>;
 }
 
 /// This trait means that the implementer can be used as a `FromSegments` request guard, and that

--- a/rocket-okapi/src/request/mod.rs
+++ b/rocket-okapi/src/request/mod.rs
@@ -1,7 +1,7 @@
 mod from_data_impls;
 mod from_param_impls;
-mod from_query_param_impls;
 mod from_query_multi_param_impls;
+mod from_query_param_impls;
 
 use super::gen::OpenApiGenerator;
 use super::Result;
@@ -40,7 +40,11 @@ pub trait OpenApiFromSegments<'r>: rocket::request::FromSegments<'r> {
 pub trait OpenApiFromFormValue<'r>: rocket::request::FromFormValue<'r> {
     /// Return a `RequestBody` containing the information required to document the `FromFormValue`
     /// for implementer.
-    fn query_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result<Parameter>;
+    fn query_parameter(
+        gen: &mut OpenApiGenerator,
+        name: String,
+        required: bool,
+    ) -> Result<Parameter>;
 }
 
 /// This trait means that the implementer can be used as a `FromQuery` request guard, and that this
@@ -48,5 +52,9 @@ pub trait OpenApiFromFormValue<'r>: rocket::request::FromFormValue<'r> {
 pub trait OpenApiFromQuery<'r>: rocket::request::FromQuery<'r> {
     /// Return a `RequestBody` containing the information required to document the `FromQuery` for
     /// implementer.
-    fn query_multi_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result<Vec<Parameter>>;
+    fn query_multi_parameter(
+        gen: &mut OpenApiGenerator,
+        name: String,
+        required: bool,
+    ) -> Result<Vec<Parameter>>;
 }

--- a/rocket-okapi/src/response/responder_impls.rs
+++ b/rocket-okapi/src/response/responder_impls.rs
@@ -100,9 +100,7 @@ status_responder!(Forbidden, 403);
 status_responder!(NotFound, 404);
 status_responder!(Conflict, 409);
 
-impl OpenApiResponder<'_>
-    for rocket::response::status::NoContent
-{
+impl OpenApiResponder<'_> for rocket::response::status::NoContent {
     fn responses(_: &mut OpenApiGenerator) -> Result {
         let mut responses = Responses::default();
         set_status_code(&mut responses, 204)?;

--- a/rocket-okapi/src/swagger_ui.rs
+++ b/rocket-okapi/src/swagger_ui.rs
@@ -61,15 +61,15 @@ pub struct SwaggerUIConfig {
     /// your web ui. If this field is populated, the `url` field is not used.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub urls: Vec<UrlObject>,
-    
+
     // display options:
     /// If set to true, enables deep linking for tags and operations. See the
     /// [Deep Linking documentation](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/deep-linking.md)
     /// for more information.
-    /// Default: `false`. 
+    /// Default: `false`.
     pub deep_linking: bool,
     /// Controls the display of operationId in operations list.
-    /// Default: `false`. 
+    /// Default: `false`.
     pub display_operation_id: bool,
     /// The default expansion depth for models (set to -1 completely hide the models).
     /// Default: `1`.


### PR DESCRIPTION
Fixes #25
Adds query parameters in url. All parameters are required by default and 
using `Option<..>` will make the parameter optional. 
This is also how rocket expects the values.
As noted this fixes issue #25 where this was requested.
Also add this to the example.