### PR TITLE
Added Support for Security Schemes

### DIFF
--- a/okapi/src/openapi3.rs
+++ b/okapi/src/openapi3.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 type Object = Map<String, Value>;
 
-type SecurityRequirement = Map<String, Vec<String>>;
+pub type SecurityRequirement = Map<String, Vec<String>>;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "derive_json_schema", derive(JsonSchema))]
@@ -352,8 +352,6 @@ pub struct Header {
 #[cfg_attr(feature = "derive_json_schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct SecurityScheme {
-    #[serde(rename = "type")]
-    pub schema_type: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(flatten)]

--- a/rocket-okapi-codegen/Cargo.toml
+++ b/rocket-okapi-codegen/Cargo.toml
@@ -17,3 +17,4 @@ darling = "0.10"
 syn = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
+okapi = { version = "0.5.0-alpha-1", path = "../okapi" }

--- a/rocket-okapi-codegen/src/lib.rs
+++ b/rocket-okapi-codegen/src/lib.rs
@@ -41,6 +41,11 @@ pub fn routes_with_openapi(input: TokenStream) -> TokenStream {
     routes_with_openapi::parse(input)
 }
 
+#[proc_macro]
+pub fn routes_with_openapi_with_settings(input: TokenStream) -> TokenStream {
+    routes_with_openapi::parse_with_settings(input)
+}
+
 fn get_add_operation_fn_name(route_fn_name: &Ident) -> Ident {
     Ident::new(
         &format!("okapi_add_operation_for_{}_", route_fn_name),

--- a/rocket-okapi/src/gen.rs
+++ b/rocket-okapi/src/gen.rs
@@ -77,6 +77,8 @@ impl OpenApiGenerator {
             }
         }
 
+
+
         OpenApi {
             openapi: "3.0.0".to_owned(),
             paths: {
@@ -91,6 +93,7 @@ impl OpenApiGenerator {
             },
             components: Some(Components {
                 schemas: Map::from_iter(schemas.into_iter().map(|(k, v)| (k, v.into()))),
+                security_schemes: self.settings.security_schemes,
                 ..Default::default()
             }),
             ..Default::default()

--- a/rocket-okapi/src/settings.rs
+++ b/rocket-okapi/src/settings.rs
@@ -1,3 +1,4 @@
+use okapi::{Map, openapi3::{RefOr, SecurityScheme, SecuritySchemeData}};
 use schemars::gen::SchemaSettings;
 
 /// Settings which are used to customise the behaviour of the `OpenApiGenerator`.
@@ -8,6 +9,8 @@ pub struct OpenApiSettings {
     /// The path to the json file that contains the API specification. Then default is
     /// `openapi.json`.
     pub json_path: String,
+    /// SecuritySchemes to be added to the api
+    pub security_schemes: Map<String, RefOr<SecurityScheme>>,
 }
 
 impl Default for OpenApiSettings {
@@ -15,6 +18,7 @@ impl Default for OpenApiSettings {
         OpenApiSettings {
             schema_settings: SchemaSettings::openapi3(),
             json_path: "/openapi.json".to_owned(),
+            security_schemes: Map::new(),
         }
     }
 }
@@ -26,4 +30,10 @@ impl OpenApiSettings {
             ..Default::default()
         }
     }
+
+    /// Adds a `SecurityScheme` to an instance of `OpenApiSettings`
+    pub fn add_security_scheme(&mut self, name: String, security:SecuritySchemeData, description: Option<String>){
+        self.security_schemes.insert(name, RefOr::Object{0:SecurityScheme{description:description, extensions:Map::new(), data: security}});
+    }
+
 }


### PR DESCRIPTION
Introduces a way to specify the security of an operation:
The [openapi] macro was extended with an optional string parameter: security
`#[openapi(security = "x-api-key")]`
that specifies the attached Security Scheme. This currently does not supporting setting the scope.

These can be added via the OpenApiSettings which has been extended to hold all security schemes.
```
let mut settings = OpenApiSettings::default();
    settings.add_security_scheme("x-api-key".to_owned(), SecuritySchemeData::ApiKey {name: "x-api-key".to_owned(),location: "header".to_owned()},None);
```
Which can be used with a new macro `routes_with_openapi_with_settings` which takes as last argument the settings.
Note: This could be cleaned up with a nicer interface and implementation.
```
routes_with_openapi_with_settings![
                route1,
                route2,
                settings
 ],
```
    