### PR TITLE
Request guards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ members = [
     "examples/custom_schema",
     "examples/uuid",
     "examples/special-types",
+    "examples/secure_request_guard"
 ]

--- a/examples/secure_request_guard/.gitignore
+++ b/examples/secure_request_guard/.gitignore
@@ -1,0 +1,4 @@
+/target
+**/*.rs.bk
+Cargo.lock
+/.idea

--- a/examples/secure_request_guard/Cargo.toml
+++ b/examples/secure_request_guard/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "secure_request_guard"
 version = "0.1.0"
-authors = ["Kristoffer Ödmark <kristoffer.odmark90@gmail.com>"]
+authors = ["Kristoffer Ödmark <kristoffer.odmark90@gmail.com>", "Ralph Bisschops <ralph.bisschops.dev@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-rocket = { version = "0.5.0-rc.1", default-features = false, features = ["json"] }
+rocket = { version = "0.5.0-rc.1", default-features = false, features = ["json", "secrets"] }
 schemars = { version = "0.8"}
 okapi = { version = "0.6.0-alpha-1", path = "../../okapi" }
-rocket_okapi = { version = "0.8.0-alpha-1", path = "../../rocket-okapi", features = ["swagger"] }
+rocket_okapi = { version = "0.8.0-alpha-1", path = "../../rocket-okapi", features = ["rapidoc", "swagger", "secrets"] }
 serde = "1.0"
 tokio = "1.6"
+serde_json = "1.0"

--- a/examples/secure_request_guard/Cargo.toml
+++ b/examples/secure_request_guard/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 rocket = { version = "0.5.0-rc.1", default-features = false, features = ["json"] }
 schemars = { version = "0.8"}
 okapi = { version = "0.6.0-alpha-1", path = "../../okapi" }
-rocket_okapi = { version = "0.7.0-alpha-1", path = "../../rocket-okapi" }
+rocket_okapi = { version = "0.8.0-alpha-1", path = "../../rocket-okapi", features = ["swagger"] }
 serde = "1.0"
 tokio = "1.6"

--- a/examples/secure_request_guard/Cargo.toml
+++ b/examples/secure_request_guard/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "secure_request_guard"
+version = "0.1.0"
+authors = ["Kristoffer Ödmark <kristoffer.odmark90@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+rocket = { version = "0.5.0-rc.1", default-features = false, features = ["json"] }
+schemars = { version = "0.8"}
+okapi = { version = "0.6.0-alpha-1", path = "../../okapi" }
+rocket_okapi = { version = "0.7.0-alpha-1", path = "../../rocket-okapi" }
+serde = "1.0"
+tokio = "1.6"

--- a/examples/secure_request_guard/README.md
+++ b/examples/secure_request_guard/README.md
@@ -1,0 +1,8 @@
+# Secure Request Guard
+
+A simple web API written using [Rocket](https://rocket.rs/) including openapi. It contains one route that needs the correct key provided
+to allow access. This example implements the security called by an api key that needs to be included
+in the header from the following: [apikeys] (https://swagger.io/docs/specification/authentication/api-keys/)
+
+the key is "hello"
+

--- a/examples/secure_request_guard/src/api_key.rs
+++ b/examples/secure_request_guard/src/api_key.rs
@@ -1,0 +1,106 @@
+//! ------ ApiKey (in http header, query or cookie) ------
+use okapi::openapi3::{Object, Responses, SecurityRequirement, SecurityScheme, SecuritySchemeData};
+use rocket::serde::json::Json;
+use rocket::{
+    get,
+    http::Status,
+    request::{self, FromRequest, Outcome},
+};
+use rocket_okapi::{
+    gen::OpenApiGenerator,
+    openapi,
+    request::{OpenApiFromRequest, RequestHeaderInput},
+};
+
+pub struct ApiKey(String);
+
+// Implement the actual checks for the authentication
+#[rocket::async_trait]
+impl<'a> FromRequest<'a> for ApiKey {
+    type Error = &'static str;
+    async fn from_request(
+        request: &'a request::Request<'_>,
+    ) -> request::Outcome<Self, Self::Error> {
+        // Get the key from the http header
+        match request.headers().get_one("x-api-key") {
+            Some(key) => {
+                if key == "mykey" {
+                    Outcome::Success(ApiKey(key.to_owned()))
+                } else {
+                    Outcome::Failure((Status::Unauthorized, "Api key is invalid."))
+                }
+            }
+            None => Outcome::Failure((Status::BadRequest, "Missing `x-api-key` header.")),
+        }
+        // For more info see: https://rocket.rs/v0.5-rc/guide/state/#within-guards
+    }
+}
+
+impl<'a> OpenApiFromRequest<'a> for ApiKey {
+    fn from_request_input(
+        _gen: &mut OpenApiGenerator,
+        _name: String,
+        _required: bool,
+    ) -> rocket_okapi::Result<RequestHeaderInput> {
+        // Setup global requirement for Security scheme
+        let security_scheme = SecurityScheme {
+            description: Some("Requires an API key to access, key is: `mykey`.".to_owned()),
+            // Setup data requirements.
+            // This can be part of the `header`, `query` or `cookie`.
+            // In this case the header `x-api-key: mykey` needs to be set.
+            data: SecuritySchemeData::ApiKey {
+                name: "x-api-key".to_owned(),
+                location: "header".to_owned(),
+            },
+            extensions: Object::default(),
+        };
+        // Add the requirement for this route/endpoint
+        // This can change between routes.
+        let mut security_req = SecurityRequirement::new();
+        // Each security requirement needs to be met before access is allowed.
+        security_req.insert("ApiKeyAuth".to_owned(), Vec::new());
+        // These vvvvvvv-----^^^^^^^^^^ values need to match exactly!
+        Ok(RequestHeaderInput::Security(
+            "ApiKeyAuth".to_owned(),
+            security_scheme,
+            security_req,
+        ))
+    }
+
+    // Optionally add responses
+    // Also see `main.rs` part of this.
+    fn get_responses(gen: &mut OpenApiGenerator) -> rocket_okapi::Result<Responses> {
+        let mut responses = Responses::default();
+        // It can return a "400 BadRequest" and a "401 Unauthorized"
+        // In both cases we just return a what we have set in the catches (if any).
+        // In our cases this is: `crate::MyError`
+        let schema = gen.json_schema::<crate::MyError>();
+        // Add "400 BadRequest"
+        rocket_okapi::util::add_schema_response(
+            &mut responses,
+            400,
+            "application/json",
+            schema.clone(),
+        )?;
+        // Add "401 Unauthorized"
+        rocket_okapi::util::add_schema_response(&mut responses, 401, "application/json", schema)?;
+        Ok(responses)
+    }
+}
+
+/// # ApiKey (in http header, query or cookie)
+///
+/// The key is: `mykey`
+/// This is a common way of checking the authentication.
+/// (make sure this is only sent over HTTPS, don't want secrets to leak)
+///
+/// Using `query` is not recommended for secrets!
+/// For more info see:
+/// https://owasp.org/www-community/vulnerabilities/Information_exposure_through_query_strings_in_url
+#[openapi]
+#[get("/apikey")]
+pub fn api_key(key: ApiKey) -> Json<&'static str> {
+    // Use api key
+    let _seems_you_have_access = key;
+    Json("You got access")
+}

--- a/examples/secure_request_guard/src/cookies.rs
+++ b/examples/secure_request_guard/src/cookies.rs
@@ -1,0 +1,72 @@
+//! ------ Just Cookies (for just 1 route/endpoint) ------
+
+use okapi::openapi3::{Object, Parameter, ParameterValue};
+use rocket::outcome::IntoOutcome;
+use rocket::serde::json::Json;
+use rocket::{
+    get,
+    request::{self, FromRequest},
+};
+use rocket_okapi::{
+    gen::OpenApiGenerator,
+    openapi,
+    request::{OpenApiFromRequest, RequestHeaderInput},
+};
+
+pub struct CookieAuth(String);
+
+// Implement the actual checks for the authentication
+#[rocket::async_trait]
+impl<'a> FromRequest<'a> for CookieAuth {
+    type Error = &'static str;
+    async fn from_request(
+        request: &'a request::Request<'_>,
+    ) -> request::Outcome<Self, Self::Error> {
+        request
+            .cookies()
+            .get_private("user_id") // Requires "secrets" feature flag
+            .and_then(|cookie| cookie.value().parse().ok())
+            .map(CookieAuth)
+            .or_forward(())
+    }
+}
+
+impl<'a> OpenApiFromRequest<'a> for CookieAuth {
+    fn from_request_input(
+        gen: &mut OpenApiGenerator,
+        _name: String,
+        required: bool,
+    ) -> rocket_okapi::Result<RequestHeaderInput> {
+        let schema = gen.json_schema::<String>();
+        Ok(RequestHeaderInput::Parameter(Parameter {
+            name: "user_id".to_owned(),
+            location: "cookie".to_owned(),
+            description: None,
+            required,
+            deprecated: false,
+            allow_empty_value: false,
+            value: ParameterValue::Schema {
+                style: None,
+                explode: None,
+                allow_reserved: false,
+                schema,
+                example: None,
+                examples: None,
+            },
+            extensions: Object::default(),
+        }))
+    }
+}
+
+/// # Just Cookies (for just 1 route/endpoint)
+///
+/// (make sure this is only sent over HTTPS, don't want secrets to leak)
+///
+/// Note: Cookies will not work with the `Try` button because of
+/// [Technical limitations](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name).
+#[openapi]
+#[get("/cookie_auth")]
+pub fn cookie_auth(user: CookieAuth) -> Json<&'static str> {
+    let _seems_you_have_access = user;
+    Json("You got access")
+}

--- a/examples/secure_request_guard/src/http_auth.rs
+++ b/examples/secure_request_guard/src/http_auth.rs
@@ -1,0 +1,85 @@
+//! ------ HTTP `Authorization` header ------
+
+use okapi::openapi3::{Object, SecurityRequirement, SecurityScheme, SecuritySchemeData};
+use rocket::serde::json::Json;
+use rocket::{
+    get,
+    http::Status,
+    request::{self, FromRequest, Outcome},
+};
+use rocket_okapi::{
+    gen::OpenApiGenerator,
+    openapi,
+    request::{OpenApiFromRequest, RequestHeaderInput},
+};
+
+pub struct HttpAuth(String);
+
+// Implement the actual checks for the authentication
+#[rocket::async_trait]
+impl<'a> FromRequest<'a> for HttpAuth {
+    type Error = &'static str;
+    async fn from_request(
+        request: &'a request::Request<'_>,
+    ) -> request::Outcome<Self, Self::Error> {
+        // Get the token from the http header
+        match request.headers().get_one("Authorization") {
+            Some(token) => {
+                if token == "Bearer mytoken" {
+                    Outcome::Success(HttpAuth(token.to_owned()))
+                } else {
+                    Outcome::Failure((Status::Unauthorized, "Auth is invalid."))
+                }
+            }
+            None => Outcome::Failure((Status::BadRequest, "Missing `Authorization` header.")),
+        }
+        // For more info see: https://rocket.rs/v0.5-rc/guide/state/#within-guards
+    }
+}
+
+impl<'a> OpenApiFromRequest<'a> for HttpAuth {
+    fn from_request_input(
+        _gen: &mut OpenApiGenerator,
+        _name: String,
+        _required: bool,
+    ) -> rocket_okapi::Result<RequestHeaderInput> {
+        // Setup global requirement for Security scheme
+        let security_scheme = SecurityScheme {
+            description: Some(
+                "Requires an Bearer token to access, token is: `mytoken`.".to_owned(),
+            ),
+            // Setup data requirements.
+            // In this case the header `Authorization: mytoken` needs to be set.
+            data: SecuritySchemeData::Http {
+                scheme: "bearer".to_owned(), // `basic`, `digest`, ...
+                // Just gives use a hint to the format used
+                bearer_format: Some("bearer".to_owned()),
+            },
+            extensions: Object::default(),
+        };
+        // Add the requirement for this route/endpoint
+        // This can change between routes.
+        let mut security_req = SecurityRequirement::new();
+        // Each security requirement needs to be met before access is allowed.
+        security_req.insert("HttpAuth".to_owned(), Vec::new());
+        // These vvvvvvv-----^^^^^^^^ values need to match exactly!
+        Ok(RequestHeaderInput::Security(
+            "HttpAuth".to_owned(),
+            security_scheme,
+            security_req,
+        ))
+    }
+}
+
+/// # HTTP `Authorization` header
+///
+/// The token is: `mytoken`
+/// This is a common way of checking the authentication.
+/// (make sure this is only sent over HTTPS, don't want secrets to leak)
+#[openapi]
+#[get("/http_auth")]
+pub fn http_auth(token: HttpAuth) -> Json<&'static str> {
+    // Use api key
+    let _seems_you_have_access = token;
+    Json("You got access")
+}

--- a/examples/secure_request_guard/src/main.rs
+++ b/examples/secure_request_guard/src/main.rs
@@ -1,4 +1,6 @@
-use okapi::openapi3::{Object, Responses, SecurityRequirement, SecurityScheme, SecuritySchemeData};
+use okapi::openapi3::{
+    Object, Responses, SchemeIdentifier, SecurityRequirement, SecurityScheme, SecuritySchemeData,
+};
 use rocket::serde::json::Json;
 use rocket::{
     get,
@@ -57,7 +59,11 @@ impl<'a, 'r> OpenApiFromRequest<'a> for KeyAuthorize {
         // https://swagger.io/docs/specification/authentication/basic-authentication/
         let security_scheme = SecurityScheme {
             description: Some("requires a key to access".into()),
-            scheme_identifier: "FixedKeyApiKeyAuth".into(),
+            // this will show where and under which name the value will be found in the HTTP header
+            // in this case, the header key x-api-key will be searched
+            // other alternatives are "query", "cookie" according to the openapi specs.
+            // [link](https://swagger.io/specification/#security-scheme-object)
+            // which also is where you can find examples of how to create a JWT scheme for example
             data: SecuritySchemeData::ApiKey {
                 name: "x-api-key".into(),
                 location: "header".into(),
@@ -65,9 +71,16 @@ impl<'a, 'r> OpenApiFromRequest<'a> for KeyAuthorize {
             extensions: Object::default(),
         };
 
+        // scheme identifier is the keyvalue under which this security_scheme will be filed in
+        // the openapi.json file
+        let scheme_identifier = SchemeIdentifier {
+            scheme_identifier: "FixedKeyApiKeyAuth".into(),
+        };
+
         Ok(RequestHeaderInput::Security((
             security_scheme,
             security_req,
+            scheme_identifier,
         )))
     }
 }

--- a/examples/secure_request_guard/src/main.rs
+++ b/examples/secure_request_guard/src/main.rs
@@ -8,10 +8,9 @@ use rocket::{
 };
 use rocket_okapi::{
     gen::OpenApiGenerator,
-    openapi,
+    openapi, openapi_get_routes,
     request::{OpenApiFromRequest, RequestHeaderInput},
     response::OpenApiResponder,
-    routes_with_openapi,
     swagger_ui::{make_swagger_ui, SwaggerUIConfig},
 };
 
@@ -100,7 +99,7 @@ async fn main() {
     let rocket_config = Config::debug_default();
 
     let e = rocket::custom(rocket_config)
-        .mount("/", routes_with_openapi![restricted])
+        .mount("/", openapi_get_routes![restricted])
         .mount(
             "/api/",
             make_swagger_ui(&SwaggerUIConfig {

--- a/examples/secure_request_guard/src/main.rs
+++ b/examples/secure_request_guard/src/main.rs
@@ -1,0 +1,113 @@
+use okapi::openapi3::{Object, Responses, SecurityRequirement, SecurityScheme, SecuritySchemeData};
+use rocket::serde::json::Json;
+use rocket::{
+    get,
+    http::Status,
+    request::{self, FromRequest, Outcome},
+    Config, Response,
+};
+use rocket_okapi::{
+    gen::OpenApiGenerator,
+    openapi,
+    request::{OpenApiFromRequest, RequestHeaderInput},
+    response::OpenApiResponder,
+    routes_with_openapi,
+    swagger_ui::{make_swagger_ui, SwaggerUIConfig},
+};
+
+pub struct KeyAuthorize;
+
+#[rocket::async_trait]
+impl<'a> FromRequest<'a> for KeyAuthorize {
+    type Error = ();
+    async fn from_request(
+        request: &'a request::Request<'_>,
+    ) -> request::Outcome<Self, Self::Error> {
+        // Same as in the name
+        let keys: Vec<_> = request.headers().get("x-api-key").collect();
+
+        // Get the key from the http header
+        let out = match keys.len() {
+            1 => {
+                let key = &keys[0][..];
+                if key == "hello" {
+                    Outcome::Success(KeyAuthorize)
+                } else {
+                    Outcome::Failure((Status::Unauthorized, ()))
+                }
+            }
+            _ => {
+                println!("wrong amount of authorization headers found");
+                Outcome::Failure((Status::BadRequest, ()))
+            }
+        };
+        out
+    }
+}
+
+impl<'a, 'r> OpenApiFromRequest<'a> for KeyAuthorize {
+    fn request_input(
+        _gen: &mut OpenApiGenerator,
+        _name: String,
+    ) -> rocket_okapi::Result<RequestHeaderInput> {
+        let mut security_req = SecurityRequirement::new();
+        // each security requirement needs a specific key in the openapi docs
+        security_req.insert("example_security".into(), Vec::new());
+
+        // The scheme for the security needs to be defined as well
+        // https://swagger.io/docs/specification/authentication/basic-authentication/
+        let security_scheme = SecurityScheme {
+            description: Some("requires a key to access".into()),
+            scheme_identifier: "FixedKeyApiKeyAuth".into(),
+            data: SecuritySchemeData::ApiKey {
+                name: "x-api-key".into(),
+                location: "header".into(),
+            },
+            extensions: Object::default(),
+        };
+
+        Ok(RequestHeaderInput::Security((
+            security_scheme,
+            security_req,
+        )))
+    }
+}
+
+/// Defines the possible responses for this request guard for the openapi docs (not used yet)
+impl<'a, 'r: 'a> OpenApiResponder<'a, 'r> for KeyAuthorize {
+    fn responses(_: &mut OpenApiGenerator) -> rocket_okapi::Result<Responses> {
+        let responses = Responses::default();
+        Ok(responses)
+    }
+}
+
+/// Returns an empty, default `Response`. Always returns `Ok`.
+/// Defines the possible response for this request guard
+impl<'a, 'r: 'a> rocket::response::Responder<'a, 'r> for KeyAuthorize {
+    fn respond_to(self, _: &rocket::request::Request<'_>) -> rocket::response::Result<'static> {
+        Ok(Response::new())
+    }
+}
+
+#[openapi]
+#[get("/restricted")]
+pub fn restricted(_key: KeyAuthorize) -> Json<String> {
+    Json("You got access here, hurray".into())
+}
+
+#[tokio::main]
+async fn main() {
+    let rocket_config = Config::debug_default();
+
+    let e = rocket::custom(rocket_config)
+        .mount("/", routes_with_openapi![restricted])
+        .mount(
+            "/api/",
+            make_swagger_ui(&SwaggerUIConfig {
+                url: "/openapi.json".to_string(),
+                ..Default::default()
+            }),
+        )
+        .launch()
+        .await;
+}

--- a/examples/secure_request_guard/src/no_auth.rs
+++ b/examples/secure_request_guard/src/no_auth.rs
@@ -1,0 +1,33 @@
+//! ------ No special authentication ------
+
+use rocket::serde::json::Json;
+use rocket::{
+    get,
+    request::{self, FromRequest, Outcome},
+};
+use rocket_okapi::{openapi, request::OpenApiFromRequest};
+
+#[derive(OpenApiFromRequest)]
+pub struct NoSpecialAuthentication;
+
+#[rocket::async_trait]
+impl<'a> FromRequest<'a> for NoSpecialAuthentication {
+    type Error = &'static str;
+    async fn from_request(
+        _request: &'a request::Request<'_>,
+    ) -> request::Outcome<Self, Self::Error> {
+        Outcome::Success(NoSpecialAuthentication)
+    }
+}
+
+/// # No special authentication
+/// This is most often used then you have something that it not related to authentication.
+/// For example database connections, or other managed (static) data.
+/// https://rocket.rs/v0.5-rc/guide/state/
+#[openapi]
+#[get("/no_auth")]
+pub fn no_special_auth(something: NoSpecialAuthentication) -> Json<&'static str> {
+    // Use `something` here
+    let _use_value = something;
+    Json("No special authentication needed.")
+}

--- a/examples/secure_request_guard/src/oauth2.rs
+++ b/examples/secure_request_guard/src/oauth2.rs
@@ -1,0 +1,103 @@
+//! ------ OAuth 2.0 flows (authorizationCode, implicit, password, clientCredentials) ------
+use okapi::openapi3::{
+    OAuthFlows, Object, SecurityRequirement, SecurityScheme, SecuritySchemeData,
+};
+use rocket::serde::json::{json, Json};
+use rocket::{
+    get,
+    http::Status,
+    request::{self, FromRequest, Outcome},
+};
+use rocket_okapi::{
+    gen::OpenApiGenerator,
+    openapi,
+    request::{OpenApiFromRequest, RequestHeaderInput},
+};
+
+pub struct OAuth2AuthCode;
+
+// Implement the actual checks for the authentication
+#[rocket::async_trait]
+impl<'a> FromRequest<'a> for OAuth2AuthCode {
+    type Error = &'static str;
+    async fn from_request(
+        request: &'a request::Request<'_>,
+    ) -> request::Outcome<Self, Self::Error> {
+        // Get the jwt from the http header
+        match request.headers().get_one("Authorization") {
+            Some(jwt) => {
+                // TODO Use proper OAuth2/JWT verification here. (This is just en example)
+                if jwt.starts_with("Bearer ") {
+                    Outcome::Success(OAuth2AuthCode)
+                } else {
+                    Outcome::Failure((Status::Unauthorized, "JWT is invalid."))
+                }
+            }
+            None => Outcome::Failure((Status::BadRequest, "Missing `Authorization` header.")),
+        }
+    }
+}
+
+impl<'a> OpenApiFromRequest<'a> for OAuth2AuthCode {
+    fn from_request_input(
+        _gen: &mut OpenApiGenerator,
+        _name: String,
+        _required: bool,
+    ) -> rocket_okapi::Result<RequestHeaderInput> {
+        // Setup global requirement for Security scheme
+        let security_scheme = SecurityScheme {
+            description: Some(
+                "Requires an API key to access, \
+                client_id = `interactive.confidential`, \
+                client_secret = `secret`. \
+                (Does not work in Swagger UI)"
+                    .to_owned(),
+            ),
+            // Setup data requirements.
+            data: SecuritySchemeData::OAuth2 {
+                // Other flows are very similar.
+                // For more info see: https://swagger.io/docs/specification/authentication/oauth2/
+                flows: OAuthFlows::AuthorizationCode {
+                    authorization_url: "https://demo.identityserver.io/connect/authorize"
+                        .to_owned(),
+                    token_url: "https://demo.identityserver.io/connect/token".to_owned(),
+                    refresh_url: None,
+                    scopes: okapi::map! {
+                        "openid".to_owned() => "Ability to access openid".to_owned(),
+                        "profile".to_owned() => "Ability to access profile".to_owned(),
+                        "email".to_owned() => "Ability to access email".to_owned(),
+                        "api".to_owned() => "Ability to use api".to_owned(),
+                        "offline_access".to_owned() => "Ability for offline access".to_owned(),
+                    },
+                    extensions: Object::default(),
+                },
+            },
+            // Add example data for RapiDoc
+            extensions: okapi::map! {
+                "x-client-id".to_owned() => json!("interactive.confidential"),
+                "x-client-secret".to_owned() => json!("secret"),
+            },
+        };
+        // Add the requirement for this route/endpoint
+        // This can change between routes.
+        let mut security_req = SecurityRequirement::new();
+        // Each security requirement needs to be met before access is allowed.
+        security_req.insert("OAuth2AuthCode".to_owned(), vec!["profile".to_owned()]);
+        // These vvvvvvv-----^^^^^^^^^^ values need to match exactly!
+        Ok(RequestHeaderInput::Security(
+            "OAuth2AuthCode".to_owned(),
+            security_scheme,
+            security_req,
+        ))
+    }
+}
+
+/// # OAuth 2.0 flow: Authorization Code
+///
+/// This endpoint requires `profile` scope. (not checked)
+#[openapi]
+#[get("/oauth2_auth_code/get_user")]
+pub fn oauth2_auth_code_get_user(auth: OAuth2AuthCode) -> Json<&'static str> {
+    let _seems_you_have_access = auth;
+    Json("You got access")
+}

--- a/examples/secure_request_guard/src/open_id.rs
+++ b/examples/secure_request_guard/src/open_id.rs
@@ -1,0 +1,70 @@
+//! ------ OpenID Connect ------
+
+use okapi::openapi3::{Object, SecurityRequirement, SecurityScheme, SecuritySchemeData};
+use rocket::serde::json::Json;
+use rocket::{
+    get,
+    request::{self, FromRequest, Outcome},
+};
+use rocket_okapi::{
+    gen::OpenApiGenerator,
+    openapi,
+    request::{OpenApiFromRequest, RequestHeaderInput},
+};
+
+pub struct OpenId(String);
+
+// Implement the actual checks for the authentication
+#[rocket::async_trait]
+impl<'a> FromRequest<'a> for OpenId {
+    type Error = &'static str;
+    async fn from_request(
+        _request: &'a request::Request<'_>,
+    ) -> request::Outcome<Self, Self::Error> {
+        // Implement read OpenId flow here, this is to much work for an example.
+        // Good luck!
+        Outcome::Success(OpenId("Some info".to_owned()))
+    }
+}
+
+impl<'a> OpenApiFromRequest<'a> for OpenId {
+    fn from_request_input(
+        _gen: &mut OpenApiGenerator,
+        _name: String,
+        _required: bool,
+    ) -> rocket_okapi::Result<RequestHeaderInput> {
+        // Setup global requirement for Security scheme
+        let security_scheme = SecurityScheme {
+            description: Some(
+                "Use OpenID Connect to authenticate. (does not work in RapiDoc at all)".to_owned(),
+            ),
+            data: SecuritySchemeData::OpenIdConnect {
+                open_id_connect_url:
+                    "https://demo.identityserver.io/.well-known/openid-configuration".to_owned(),
+            },
+            extensions: Object::default(),
+        };
+        // Add the requirement for this route/endpoint
+        // This can change between routes.
+        let mut security_req = SecurityRequirement::new();
+        // Each security requirement needs to be met before access is allowed.
+        security_req.insert("OpenID".to_owned(), Vec::new());
+        // These vvvv-------^^^^^^^ values need to match exactly!
+        Ok(RequestHeaderInput::Security(
+            "OpenID".to_owned(),
+            security_scheme,
+            security_req,
+        ))
+    }
+}
+
+/// # OpenID Connect
+///
+/// This is not implemented, so this will not work correctly.
+#[openapi]
+#[get("/open_id")]
+pub fn open_id(data: OpenId) -> Json<&'static str> {
+    // Use data
+    let _seems_you_have_access = data;
+    Json("You got access")
+}

--- a/okapi/CHANGELOG.md
+++ b/okapi/CHANGELOG.md
@@ -9,14 +9,19 @@ This project follows the [Semantic Versioning standard](https://semver.org/).
 - Allow customization of OpenApi object.
 - Allow merging of OpenApi objects.
 - Added `log v0.4` as a dependency.
+- Added `map!` macro for easy creation of `okapi::Map` objects.
 
 ### Changed
+
+- Change `OAuthFlows` to better represent the different flows and allowed values within them.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- Fixed casing in `SecuritySchemeData`.
 
 ### Security
 

--- a/okapi/src/lib.rs
+++ b/okapi/src/lib.rs
@@ -6,3 +6,32 @@ pub type MapEntry<'a, K, V> = schemars::MapEntry<'a, K, V>;
 
 pub mod merge;
 pub mod openapi3;
+
+/// Macro to crate an `okapi::Map` with a number of key-value pairs in it.
+///
+/// # Examples
+///
+/// ```rust
+/// use okapi::Map;
+/// use okapi::map;
+///
+/// let my_map = map!{
+///     "user:read".to_owned() => "Ability to read user data".to_owned(),
+///     "user:write".to_owned() => "Ability to write user data".to_owned(),
+/// };
+///
+/// let mut control = Map::new();
+/// control.insert("user:read".to_owned(),"Ability to read user data".to_owned());
+/// control.insert("user:write".to_owned(),"Ability to write user data".to_owned());
+///
+/// assert_eq!(my_map, control);
+/// ```
+#[macro_export]
+macro_rules! map {
+    ($($key:expr => $val:expr),* $(,)*) => ({
+        #[allow(unused_mut)]
+        let mut map = ::okapi::Map::new();
+        $( map.insert($key, $val); )*
+        map
+    });
+}

--- a/okapi/src/merge.rs
+++ b/okapi/src/merge.rs
@@ -192,16 +192,18 @@ pub fn merge_tags(s1: &mut Vec<Tag>, s2: &[Tag]) -> Result<Vec<Tag>, MergeError>
     // Convert `Map` to `Vec`
     let mut new_tags_vec = Vec::new();
 
-    // Remove/add in reverser order
-    for _i in 0..new_tags.len() {
-        if let Some((_name, tag)) = new_tags.pop() {
+    // Remove/add in order
+    // Clone all keys because that is faster then cloning all the tags.
+    // `BTreeMap` does not implement `pop()` so can not use that.
+    // Code below works both for `BTreeMap` as for `IndexMap`.
+    let keys: Vec<String> = new_tags.keys().cloned().collect();
+    for key in keys {
+        if let Some(tag) = new_tags.remove(&key) {
             new_tags_vec.push(tag);
         } else {
             unreachable!("List sizes or same list do not match.");
         }
     }
-    // Switch the order to to keep the order consistent.
-    new_tags_vec.reverse();
     Ok(new_tags_vec)
 }
 

--- a/okapi/src/merge.rs
+++ b/okapi/src/merge.rs
@@ -1,4 +1,4 @@
-use crate::openapi3::{Components, Info, OpenApi, PathItem, Tag};
+use crate::openapi3::{Components, Info, OpenApi, PathItem, Responses, Tag};
 use crate::{Map, MapEntry};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -213,6 +213,13 @@ pub fn merge_tag(s1: &mut Tag, s2: &Tag) -> Result<(), MergeError> {
     }
     merge_opt_string(&mut s1.description, &s2.description);
     merge_option(&mut s1.external_docs, &s2.external_docs);
+    merge_map(&mut s1.extensions, &s2.extensions, "extensions");
+    Ok(())
+}
+
+pub fn merge_responses(s1: &mut Responses, s2: &Responses) -> Result<(), MergeError> {
+    merge_option(&mut s1.default, &s2.default);
+    merge_map(&mut s1.responses, &s2.responses, "responses");
     merge_map(&mut s1.extensions, &s2.extensions, "extensions");
     Ok(())
 }

--- a/okapi/src/openapi3.rs
+++ b/okapi/src/openapi3.rs
@@ -367,7 +367,7 @@ pub struct Header {
 #[serde(rename_all = "camelCase")]
 pub struct SecurityScheme {
     // unique name for the security scheme
-    pub name: String,
+    pub scheme_identifier: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(flatten)]

--- a/okapi/src/openapi3.rs
+++ b/okapi/src/openapi3.rs
@@ -366,8 +366,8 @@ pub struct Header {
 #[cfg_attr(feature = "derive_json_schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct SecurityScheme {
-    #[serde(rename = "type")]
-    pub schema_type: String,
+    // unique name for the security scheme
+    pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(flatten)]

--- a/okapi/src/openapi3.rs
+++ b/okapi/src/openapi3.rs
@@ -377,64 +377,68 @@ pub struct SecurityScheme {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "derive_json_schema", derive(JsonSchema))]
-#[serde(rename_all = "camelCase")]
-pub struct SchemeIdentifier {
-    #[serde(default)]
-    /// Unique name for the security scheme.
-    pub scheme_identifier: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "derive_json_schema", derive(JsonSchema))]
 #[serde(tag = "type", rename_all = "camelCase")]
 #[allow(clippy::large_enum_variant)]
 pub enum SecuritySchemeData {
+    #[serde(rename_all = "camelCase")]
     ApiKey {
         name: String,
         #[serde(rename = "in")]
         location: String,
     },
+    #[serde(rename_all = "camelCase")]
     Http {
         scheme: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         bearer_format: Option<String>,
     },
-    #[serde(rename = "oauth2")]
-    OAuth2 {
-        flows: OAuthFlows,
-    },
-    OpenIdConnect {
-        open_id_connect_url: String,
-    },
+    #[serde(rename = "oauth2", rename_all = "camelCase")]
+    OAuth2 { flows: OAuthFlows },
+    #[serde(rename_all = "camelCase")]
+    OpenIdConnect { open_id_connect_url: String },
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
-#[cfg_attr(feature = "derive_json_schema", derive(JsonSchema))]
-#[serde(default, rename_all = "camelCase")]
-pub struct OAuthFlows {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub implicit: Option<OAuthFlow>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub password: Option<OAuthFlow>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_credentials: Option<OAuthFlow>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub authorization_code: Option<OAuthFlow>,
-    #[serde(flatten)]
-    pub extensions: Object,
-}
-
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "derive_json_schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct OAuthFlow {
-    pub authorization_url: String,
-    pub token_url: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub refresh_url: Option<String>,
-    pub scopes: Map<String, String>,
-    #[serde(flatten)]
-    pub extensions: Object,
+pub enum OAuthFlows {
+    #[serde(rename_all = "camelCase")]
+    Implicit {
+        authorization_url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        refresh_url: Option<String>,
+        scopes: Map<String, String>,
+        #[serde(flatten)]
+        extensions: Object,
+    },
+    #[serde(rename_all = "camelCase")]
+    Password {
+        token_url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        refresh_url: Option<String>,
+        scopes: Map<String, String>,
+        #[serde(flatten)]
+        extensions: Object,
+    },
+    #[serde(rename_all = "camelCase")]
+    ClientCredentials {
+        token_url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        refresh_url: Option<String>,
+        scopes: Map<String, String>,
+        #[serde(flatten)]
+        extensions: Object,
+    },
+    #[serde(rename_all = "camelCase")]
+    AuthorizationCode {
+        authorization_url: String,
+        token_url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        refresh_url: Option<String>,
+        scopes: Map<String, String>,
+        #[serde(flatten)]
+        extensions: Object,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]

--- a/okapi/src/openapi3.rs
+++ b/okapi/src/openapi3.rs
@@ -366,8 +366,6 @@ pub struct Header {
 #[cfg_attr(feature = "derive_json_schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct SecurityScheme {
-    // unique name for the security scheme
-    pub scheme_identifier: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     // This also sets `type`
@@ -375,6 +373,15 @@ pub struct SecurityScheme {
     pub data: SecuritySchemeData,
     #[serde(flatten)]
     pub extensions: Object,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "derive_json_schema", derive(JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct SchemeIdentifier {
+    #[serde(default)]
+    /// Unique name for the security scheme.
+    pub scheme_identifier: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/okapi/src/openapi3.rs
+++ b/okapi/src/openapi3.rs
@@ -370,6 +370,7 @@ pub struct SecurityScheme {
     pub scheme_identifier: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    // This also sets `type`
     #[serde(flatten)]
     pub data: SecuritySchemeData,
     #[serde(flatten)]

--- a/rocket-okapi-codegen/src/openapi_attr/mod.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/mod.rs
@@ -222,9 +222,9 @@ fn create_route_operation_fn(
                     }
                     RequestHeaderInput::Security(s) => {
                         // Make sure to add the security scheme listing
-                        security_schemes.insert(s.0.scheme_identifier.clone(), Vec::new());
+                        security_schemes.insert(s.2.scheme_identifier.clone(), Vec::new());
                         // Add the scheme to components definition of openapi
-                        gen.add_security_scheme(s.0.scheme_identifier.clone(), s.0.clone());
+                        gen.add_security_scheme(s.2.scheme_identifier.clone(), s.0.clone());
                     }
                     _ => {
                     }

--- a/rocket-okapi-codegen/src/openapi_attr/mod.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/mod.rs
@@ -214,7 +214,6 @@ fn create_route_operation_fn(
             let request_inputs: Vec<RequestHeaderInput> = vec![#(#params),*];
 
             let mut parameters: Vec<::okapi::openapi3::RefOr<Parameter>> = Vec::new();
-
             use std::collections::BTreeMap as Map;
             let mut security_schemes = Map::new();
             for inp in request_inputs {
@@ -224,9 +223,9 @@ fn create_route_operation_fn(
                     }
                     RequestHeaderInput::Security(s) => {
                         // Make sure to add the security scheme listing
-                        security_schemes.insert(s.0.name.clone(), Vec::new());
+                        security_schemes.insert(s.0.scheme_identifier.clone(), Vec::new());
                         // Add the scheme to components definition of openapi
-                        gen.add_security_scheme(s.0.name.clone(), s.0.clone());
+                        gen.add_security_scheme(s.0.scheme_identifier.clone(), s.0.clone());
                     }
                     _ => {
                     }
@@ -258,7 +257,7 @@ fn create_route_operation_fn(
                     description: #desc,
                     security,
                     tags: vec![#(#tags),*],
-                    ..okapi::openapi3::Operation::default()
+                    ..::okapi::openapi3::Operation::default()
                 },
             });
             Ok(())

--- a/rocket-okapi-codegen/src/openapi_attr/mod.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/mod.rs
@@ -214,8 +214,7 @@ fn create_route_operation_fn(
             let request_inputs: Vec<RequestHeaderInput> = vec![#(#params),*];
 
             let mut parameters: Vec<::okapi::openapi3::RefOr<Parameter>> = Vec::new();
-            use std::collections::BTreeMap as Map;
-            let mut security_schemes = Map::new();
+            let mut security_schemes = ::okapi::Map::new();
             for inp in request_inputs {
                 match inp {
                     RequestHeaderInput::Parameter(p) => {

--- a/rocket-okapi-codegen/src/openapi_attr/mod.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/mod.rs
@@ -134,6 +134,46 @@ fn create_route_operation_fn(
         })
     }
 
+    // Request quards, checks if the items are not found in the rocket route parameters, if that is the
+    // case, we assume they are request guards
+    let mut responses = Vec::new();
+    responses.push(quote! {
+      <#return_type as ::rocket_okapi::response::OpenApiResponder>::responses(gen)?
+    });
+
+    let data_param_arg = route.data_param.clone().unwrap_or_else(|| String::new());
+    for arg_type in arg_types {
+        let ty = arg_type.1;
+        let arg = arg_type.0;
+
+        // If the items are not found in the list of path/query parameters, assume the item is a request
+        // guard and let them add to the openapi specification from the trait OpenApiFromRequest
+        // Request guards can add or define their own responses, and can thus add to the possible
+        // responses from an API
+        if route
+            .path_params()
+            .find(|item| arg == item.to_string())
+            .is_none()
+            // Verify it is not in query parameters
+            && route
+                .query_params()
+                .find(|item| arg == item.to_string())
+                .is_none()
+            && data_param_arg != arg
+        {
+            // println!("assuming request guard for: {:?}", arg);
+            params.push(quote! {
+                <#ty as ::rocket_okapi::request::OpenApiFromRequest>::request_input(gen, #arg.to_owned())?.into()
+            });
+            //TODO: implement that RequestGuards can specify the different types of responses
+
+            // Create a response for this one
+            // responses.push(quote! {
+            //   <#ty as ::rocket_okapi::response::OpenApiResponder>::responses(gen)?
+            // })
+        }
+    }
+
     let fn_name = get_add_operation_fn_name(&route_fn.sig.ident);
     let path = route
         .origin
@@ -165,7 +205,39 @@ fn create_route_operation_fn(
         ) -> ::rocket_okapi::Result<()> {
             let responses = <#return_type as ::rocket_okapi::response::OpenApiResponder>::responses(gen)?;
             let request_body = #request_body;
-            let mut parameters: Vec<::okapi::openapi3::RefOr<::okapi::openapi3::Parameter>> = vec![#(#params),*];
+
+            //###############
+            use ::rocket_okapi::request::RequestHeaderInput;
+            use ::okapi::openapi3::Parameter;
+            use ::okapi::openapi3::RefOr;
+
+            let request_inputs: Vec<RequestHeaderInput> = vec![#(#params),*];
+
+            let mut parameters: Vec<::okapi::openapi3::RefOr<Parameter>> = Vec::new();
+
+            use std::collections::BTreeMap as Map;
+            let mut security_schemes = Map::new();
+            for inp in request_inputs {
+                match inp {
+                    RequestHeaderInput::Parameter(p) => {
+                       parameters.push(p.into());
+                    }
+                    RequestHeaderInput::Security(s) => {
+                        // Make sure to add the security scheme listing
+                        security_schemes.insert(s.0.name.clone(), Vec::new());
+                        // Add the scheme to components definition of openapi
+                        gen.add_security_scheme(s.0.name.clone(), s.0.clone());
+                    }
+                    _ => {
+                    }
+                }
+            }
+            let security = if security_schemes.is_empty() {
+                None
+            } else {
+                Some(vec![security_schemes])
+            };
+
             // add nested lists
             let parameters_nested_list: Vec<Vec<::okapi::openapi3::Parameter>> = vec![#(#params_nested_list),*];
             for inner_list in parameters_nested_list{
@@ -184,6 +256,7 @@ fn create_route_operation_fn(
                     parameters,
                     summary: #title,
                     description: #desc,
+                    security,
                     tags: vec![#(#tags),*],
                     ..okapi::openapi3::Operation::default()
                 },

--- a/rocket-okapi/CHANGELOG.md
+++ b/rocket-okapi/CHANGELOG.md
@@ -23,6 +23,7 @@ of `Vec<rocket::Route>` and/or `okapi::openapi3::OpenApi`.
 - Added `log v0.4` as a dependency.
 - Added `either v1` as a dependency. (Rocket dependency)
 - Added feature flag for [`msgpack`](https://docs.rs/rocket/0.5.0-rc.1/rocket/serde/msgpack/struct.MsgPack.html)
+(Re-exposing Rocket feature flag)
 - Added support for new [`Responder`](https://docs.rs/rocket/0.5.0-rc.1/rocket/response/trait.Responder.html)
 types (implemented `OpenApiResponderInner`):
    - `std::fs::File`
@@ -67,6 +68,29 @@ types (implemented `OpenApiFromData`):
    - `&'r rocket::http::RawStr`
    - `rocket::form::Form<T>`
    - `rocket::serde::msgpack::MsgPack<T>` (only when feature `msgpack` is enabled)
+- Added feature flag for [`secrets`](https://rocket.rs/v0.5-rc/guide/requests/#secret-key)
+(Re-exposing Rocket feature flag)
+- Added support for [Request Guards](https://rocket.rs/v0.4/guide/requests/#request-guards)
+and [Security Scheme](https://swagger.io/docs/specification/authentication/)
+(aka Authentication and Authorization) (#47, #9, #3)
+- Added support for new [`FromRequest`](https://docs.rs/rocket/0.5.0-rc.1/rocket/request/trait.FromRequest.html)
+  types (implemented `OpenApiFromRequest`):
+  - `std::net::IpAddr`
+  - `std::net::SocketAddr`
+  - `Result<T, T::Error>`
+  - `Option<T>`
+  - `&'r rocket::config::Config`
+  - `&'r rocket::config::SecretKey`(only when feature `secrets` is enabled)
+  - `&'r rocket::data::Limits`
+  - `&'r rocket::http::Accept`
+  - `&'r rocket::http::ContentType`
+  - `&'r rocket::http::CookieJar<'r>`
+  - `&'r rocket::http::uri::Origin<'r>`
+  - `&'r rocket::route::Route`
+  - `rocket::http::Method`
+  - `rocket::Shutdown`
+  - `&'r rocket::State<T>`
+- Added `OpenApiFromRequest` derive macro.
 
 ### Changed
 - Swagger UI is now only available under the feature `swagger`.

--- a/rocket-okapi/Cargo.toml
+++ b/rocket-okapi/Cargo.toml
@@ -36,3 +36,6 @@ uuid = ["rocket/uuid", "schemars/uuid"]
 # Re-expost Rocket feature flag
 # https://docs.rs/rocket/0.5.0-rc.1/rocket/serde/msgpack/struct.MsgPack.html
 msgpack = ["rocket/msgpack"]
+# Re-expost Rocket feature flag
+# https://rocket.rs/v0.5-rc/guide/requests/#secret-key
+secrets = ["rocket/secrets"]

--- a/rocket-okapi/rapidoc/index.html
+++ b/rocket-okapi/rapidoc/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+    <script type="module" src="rapidoc-min.js"></script>
     <title>API Documentation - RapiDoc</title>
 </head>
 <body>

--- a/rocket-okapi/rapidoc/oauth-receiver.html
+++ b/rocket-okapi/rapidoc/oauth-receiver.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="text/javascript" src="rapidoc-min.js"></script>
+</head>
+
+<body>
+    <oauth-receiver></oauth-receiver>
+</body>
+
+</html>

--- a/rocket-okapi/src/error.rs
+++ b/rocket-okapi/src/error.rs
@@ -1,3 +1,4 @@
+use okapi::merge::MergeError;
 use std::error::Error;
 use std::fmt;
 
@@ -25,3 +26,9 @@ impl fmt::Display for OpenApiError {
 }
 
 impl Error for OpenApiError {}
+
+impl From<MergeError> for OpenApiError {
+    fn from(error: MergeError) -> Self {
+        Self::new(error.msg)
+    }
+}

--- a/rocket-okapi/src/gen.rs
+++ b/rocket-okapi/src/gen.rs
@@ -29,7 +29,7 @@ impl OpenApiGenerator {
         }
     }
 
-    /// Adds a security scheme to the generated output
+    /// Adds/Replace a security scheme to the generated output
     pub fn add_security_scheme(&mut self, name: String, scheme: SecurityScheme) {
         self.security_schemes.insert(name, scheme);
     }

--- a/rocket-okapi/src/rapidoc.rs
+++ b/rocket-okapi/src/rapidoc.rs
@@ -866,5 +866,6 @@ pub fn make_rapidoc(config: &RapiDocConfig) -> impl Into<Vec<Route>> {
             .into_route("/index.html"),
         // Add other static files
         static_file!("rapidoc-min.js", JavaScript),
+        static_file!("oauth-receiver.html", HTML),
     ]
 }

--- a/rocket-okapi/src/request/from_form_multi_param_impls.rs
+++ b/rocket-okapi/src/request/from_form_multi_param_impls.rs
@@ -1,5 +1,5 @@
 use crate::gen::OpenApiGenerator;
-use okapi::openapi3::{Parameter, ParameterValue};
+use okapi::openapi3::{Object, Parameter, ParameterValue};
 use schemars::schema::{InstanceType, Schema, SchemaObject, SingleOrVec};
 use schemars::JsonSchema;
 
@@ -7,22 +7,10 @@ use schemars::JsonSchema;
 /// that are used to create documentation.
 /// Use when manually implementing a
 /// [Form Guard](https://api.rocket.rs/master/rocket/form/trait.FromForm.html).
-/// Example:
-/// ```
-/// use rocket::form::FromForm;
-/// use serde::{Serialize, Deserialize};
-/// use schemars::JsonSchema;
-/// use rocket_okapi::{
-///     gen::OpenApiGenerator,
-///     request::OpenApiFromForm,
-///     request::get_nested_form_parameters
-/// };
 ///
-/// #[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema, FromForm)]
-/// pub struct ApiPagination{
-///     page: Option<u32>,
-///     per_page: Option<u32>,
-/// }
+/// Manual implementation is not needed anymore because of Generic trait implementation of
+/// `OpenApiFromForm` and `OpenApiFromFormField`.
+/// But still used internally for implementation.
 pub fn get_nested_form_parameters<T>(
     gen: &mut OpenApiGenerator,
     name: String,
@@ -91,6 +79,6 @@ fn parameter_from_schema(schema: SchemaObject, name: String, mut required: bool)
             example: None,
             examples: None,
         },
-        extensions: okapi::Map::default(),
+        extensions: Object::default(),
     }
 }

--- a/rocket-okapi/src/request/from_form_param_impls.rs
+++ b/rocket-okapi/src/request/from_form_param_impls.rs
@@ -1,6 +1,6 @@
 use super::{get_nested_form_parameters, OpenApiFromForm, OpenApiFromFormField};
 use crate::gen::OpenApiGenerator;
-use okapi::openapi3::{Parameter, ParameterValue};
+use okapi::openapi3::{Object, Parameter, ParameterValue};
 use schemars::JsonSchema;
 
 type Result = crate::Result<Parameter>;
@@ -39,7 +39,7 @@ where
                 example: None,
                 examples: None,
             },
-            extensions: okapi::Map::default(),
+            extensions: Object::default(),
         })
     }
 }

--- a/rocket-okapi/src/request/from_param_impls.rs
+++ b/rocket-okapi/src/request/from_param_impls.rs
@@ -1,6 +1,6 @@
 use super::OpenApiFromParam;
 use crate::gen::OpenApiGenerator;
-use okapi::openapi3::{Parameter, ParameterValue};
+use okapi::openapi3::{Object, Parameter, ParameterValue};
 use schemars::JsonSchema;
 
 type Result = crate::Result<Parameter>;
@@ -26,7 +26,7 @@ where
                 example: None,
                 examples: None,
             },
-            extensions: okapi::Map::default(),
+            extensions: Object::default(),
         })
     }
 }

--- a/rocket-okapi/src/request/from_request_impls.rs
+++ b/rocket-okapi/src/request/from_request_impls.rs
@@ -1,0 +1,23 @@
+use super::{OpenApiFromRequest, RequestHeaderInput};
+use crate::gen::OpenApiGenerator;
+use okapi::openapi3::*;
+
+impl<'a, T: Send + Sync> OpenApiFromRequest<'a> for &'a rocket::State<T> {
+    fn request_input(
+        _gen: &mut OpenApiGenerator,
+        name: String,
+    ) -> crate::Result<RequestHeaderInput> {
+        Ok(RequestHeaderInput::Parameter(Parameter {
+            required: false,
+            name: name,
+            location: "header".into(),
+            description: None,
+            deprecated: false,
+            allow_empty_value: true,
+            extensions: Object::default(),
+            value: ParameterValue::Content {
+                content: Default::default(),
+            },
+        }))
+    }
+}

--- a/rocket-okapi/src/request/from_segments_impls.rs
+++ b/rocket-okapi/src/request/from_segments_impls.rs
@@ -1,6 +1,6 @@
 use super::OpenApiFromSegments;
 use crate::gen::OpenApiGenerator;
-use okapi::openapi3::{Parameter, ParameterValue};
+use okapi::openapi3::{Object, Parameter, ParameterValue};
 use schemars::JsonSchema;
 
 type Result = crate::Result<Parameter>;
@@ -26,7 +26,7 @@ where
                 example: None,
                 examples: None,
             },
-            extensions: okapi::Map::default(),
+            extensions: Object::default(),
         })
     }
 }

--- a/rocket-okapi/src/request/mod.rs
+++ b/rocket-okapi/src/request/mod.rs
@@ -7,43 +7,44 @@ mod from_segments_impls;
 
 use super::gen::OpenApiGenerator;
 use super::Result;
-use okapi::openapi3::{
-    Parameter, RequestBody, SchemeIdentifier, SecurityRequirement, SecurityScheme,
-};
+use okapi::openapi3::{Parameter, RequestBody, Responses, SecurityRequirement, SecurityScheme};
 
 /// Expose this to the public to be use when manually implementing a
 /// [Form Guard](https://api.rocket.rs/master/rocket/form/trait.FromForm.html).
 pub use from_form_multi_param_impls::get_nested_form_parameters;
 
-/// This trait means that the implementer can be used as a `FromData` request guard,
-/// and that this can also be documented.
+/// This trait is used to document the request body that implements
+/// [`FromData`](rocket::data::FromData).
 pub trait OpenApiFromData<'r>: rocket::data::FromData<'r> {
-    /// Return a `RequestBody` containing the information required to document the `FromData` for
-    /// implementer.
+    /// Return a [`RequestBody`] containing the information required to document the
+    /// [`FromData`](rocket::data::FromData) object.
     fn request_body(gen: &mut OpenApiGenerator) -> Result<RequestBody>;
 }
 
-/// This trait means that the implementer can be used as a `FromParam` request guard,
-/// and that this can also be documented.
+/// This trait is used to document a dynamic part of a path that implements
+/// [`FromParam`](rocket::request::FromParam).
+/// For example `<user_id>` in route path.
 pub trait OpenApiFromParam<'r>: rocket::request::FromParam<'r> {
-    /// Return a `RequestBody` containing the information required to document the `FromParam` for
-    /// implementer. Path parameters.
+    /// Return a [`Parameter`] containing the information required to document the
+    /// [`FromParam`](rocket::request::FromParam) path parameter.
     fn path_parameter(gen: &mut OpenApiGenerator, name: String) -> Result<Parameter>;
 }
 
-/// This trait means that the implementer can be used as a `FromSegments` request guard,
-/// and that this can also be documented.
+/// This trait is used to document a dynamic path segment that implements
+/// [`FromSegments`](rocket::request::FromSegments).
+/// For example `<param..>` in route path.
 pub trait OpenApiFromSegments<'r>: rocket::request::FromSegments<'r> {
-    /// Return a `RequestBody` containing the information required to document the `FromSegments`
-    /// for implementer.
+    /// Return a [`Parameter`] containing the information required to document the
+    /// [`FromSegments`](rocket::request::FromSegments) path parameter.
     fn path_multi_parameter(gen: &mut OpenApiGenerator, name: String) -> Result<Parameter>;
 }
 
-/// This trait means that the implementer can be used as a `FromFormField` request guard,
-/// and that this can also be documented.
+/// This trait is used to document a query guard segment that implements
+/// [`FromFormField`](rocket::form::FromFormField).
+/// For example `?<param>` in the route's query part.
 pub trait OpenApiFromFormField<'r>: rocket::form::FromFormField<'r> {
-    /// Return a `RequestBody` containing the information required to document the `FromFormField`
-    /// for implementer.
+    /// Return a [`Parameter`] containing the information required to document the
+    /// [`FromFormField`](rocket::form::FromFormField) route's query part.
     fn form_parameter(
         gen: &mut OpenApiGenerator,
         name: String,
@@ -51,11 +52,12 @@ pub trait OpenApiFromFormField<'r>: rocket::form::FromFormField<'r> {
     ) -> Result<Parameter>;
 }
 
-/// This trait means that the implementer can be used as a `FromForm` request guard,
-/// and that this can also be documented.
+/// This trait is used to document multiple query guard segments that implement
+/// [`FromForm`](rocket::form::FromForm).
+/// For example `?<param>` in the route's query part.
 pub trait OpenApiFromForm<'r>: rocket::form::FromForm<'r> {
-    /// Return a `RequestBody` containing the information required to document the `FromForm` for
-    /// implementer.
+    /// Return a [`Vec<Parameter>`] containing the information required to document the
+    /// [`FromForm`](rocket::form::FromForm) route's query part.
     fn form_multi_parameter(
         gen: &mut OpenApiGenerator,
         name: String,
@@ -63,28 +65,52 @@ pub trait OpenApiFromForm<'r>: rocket::form::FromForm<'r> {
     ) -> Result<Vec<Parameter>>;
 }
 
-/// Commonly the items in the request header can be parameters, or authorization methods in rocket,
-/// this item will let the implementer choose what they are
+/// Used as a return type for [`OpenApiFromRequest`] trait.
+/// Defines what requirements a Request Guard needs in order to be validated.
+#[allow(clippy::large_enum_variant)]
 pub enum RequestHeaderInput {
     /// This request header requires no input anywhere
     None,
-    /// Parameter input to the path
+    /// Useful for when you want to set a header per route.
     Parameter(Parameter),
-    /// the request guard implements a security scheme
-    Security((SecurityScheme, SecurityRequirement, SchemeIdentifier)),
+    /// The request guard implements a security scheme.
+    ///
+    /// Parameters:
+    /// - The name of the [`SecurityScheme`].
+    /// - [`SecurityScheme`] is global definition of the authentication (per OpenApi spec).
+    /// - [`SecurityRequirement`] is the requirements for the route.
+    Security(String, SecurityScheme, SecurityRequirement),
 }
 
-impl Into<RequestHeaderInput> for Parameter {
-    fn into(self) -> RequestHeaderInput {
-        RequestHeaderInput::Parameter(self)
-    }
-}
+// Re-export derive trait here for convenience.
+pub use rocket_okapi_codegen::OpenApiFromRequest;
 
-/// This will let the request guards add to the openapi spec
+/// Trait that needs to be implemented for all types that implement
+/// [`FromRequest`](rocket::request::FromRequest).
+/// This trait specifies what headers or other parameters are required for this
+/// [Request Guards](https://rocket.rs/v0.5-rc/guide/requests/#request-guards)
+/// to be validated successfully.
+///
+/// If it does not quire any headers or parameters you can use the derive macro:
+/// ```rust,ignore
+/// use rocket_okapi::request::OpenApiFromRequest;
+///
+/// #[derive(OpenApiFromRequest)]
+/// pub struct MyStructName;
+/// ```
 pub trait OpenApiFromRequest<'a>: rocket::request::FromRequest<'a> {
-    /// Return a parameter for items that are found in the function call, but are not found
-    /// anywhere in the path definition by rocket, defaults to a none implementation for simplicity
-    fn request_input(_gen: &mut OpenApiGenerator, _name: String) -> Result<RequestHeaderInput> {
-        Ok(RequestHeaderInput::None)
+    /// Specifies what headers or other parameters are required for this Request Guards to validate
+    /// successfully.
+    fn from_request_input(
+        gen: &mut OpenApiGenerator,
+        name: String,
+        required: bool,
+    ) -> Result<RequestHeaderInput>;
+
+    /// Optionally add responses to the Request Guard.
+    /// This can be used for when the request guard could return a "401 Unauthorized".
+    /// Or any other responses, other then one from the default response.
+    fn get_responses(_gen: &mut OpenApiGenerator) -> Result<Responses> {
+        Ok(Responses::default())
     }
 }

--- a/rocket-okapi/src/request/mod.rs
+++ b/rocket-okapi/src/request/mod.rs
@@ -2,11 +2,12 @@ mod from_data_impls;
 mod from_form_multi_param_impls;
 mod from_form_param_impls;
 mod from_param_impls;
+mod from_request_impls;
 mod from_segments_impls;
 
 use super::gen::OpenApiGenerator;
 use super::Result;
-use okapi::openapi3::{Parameter, RequestBody};
+use okapi::openapi3::{Parameter, RequestBody, SecurityRequirement, SecurityScheme};
 
 /// Expose this to the public to be use when manually implementing a
 /// [Form Guard](https://api.rocket.rs/master/rocket/form/trait.FromForm.html).
@@ -58,4 +59,30 @@ pub trait OpenApiFromForm<'r>: rocket::form::FromForm<'r> {
         name: String,
         required: bool,
     ) -> Result<Vec<Parameter>>;
+}
+
+/// Commonly the items in the request header can be parameters, or authorization methods in rocket,
+/// this item will let the implementer choose what they are
+pub enum RequestHeaderInput {
+    /// This request header requires no input anywhere
+    None,
+    /// Parameter input to the path
+    Parameter(Parameter),
+    /// the path implements a security scheme
+    Security((SecurityScheme, SecurityRequirement)),
+}
+
+impl Into<RequestHeaderInput> for Parameter {
+    fn into(self) -> RequestHeaderInput {
+        RequestHeaderInput::Parameter(self)
+    }
+}
+
+/// This will let the request guards add to the openapi spec
+pub trait OpenApiFromRequest<'a>: rocket::request::FromRequest<'a> {
+    /// Return a parameter for items that are found in the function call, but are not found
+    /// anywhere in the path definition by rocket, defaults to a none implementation for simplicity
+    fn request_input(_gen: &mut OpenApiGenerator, _name: String) -> Result<RequestHeaderInput> {
+        Ok(RequestHeaderInput::None)
+    }
 }

--- a/rocket-okapi/src/request/mod.rs
+++ b/rocket-okapi/src/request/mod.rs
@@ -7,7 +7,9 @@ mod from_segments_impls;
 
 use super::gen::OpenApiGenerator;
 use super::Result;
-use okapi::openapi3::{Parameter, RequestBody, SecurityRequirement, SecurityScheme};
+use okapi::openapi3::{
+    Parameter, RequestBody, SchemeIdentifier, SecurityRequirement, SecurityScheme,
+};
 
 /// Expose this to the public to be use when manually implementing a
 /// [Form Guard](https://api.rocket.rs/master/rocket/form/trait.FromForm.html).
@@ -68,8 +70,8 @@ pub enum RequestHeaderInput {
     None,
     /// Parameter input to the path
     Parameter(Parameter),
-    /// the path implements a security scheme
-    Security((SecurityScheme, SecurityRequirement)),
+    /// the request guard implements a security scheme
+    Security((SecurityScheme, SecurityRequirement, SchemeIdentifier)),
 }
 
 impl Into<RequestHeaderInput> for Parameter {


### PR DESCRIPTION
- Added feature flag for `secrets`
(Re-exposing Rocket feature flag)
- Added support for Request Guards
and Security Scheme
(aka Authentication and Authorization) (Closes: #47, #9, #3)
- Added support for new `FromRequest`
  types (implemented `OpenApiFromRequest`).
- Added `OpenApiFromRequest` derive macro.
- Added `map!` macro for easy creation of `okapi::Map` objects.
- Change `OAuthFlows` to better represent the different flows and allowed values within them.
- Fixed casing in `SecuritySchemeData`.