### PR TITLE
Build docs with rapi docs and swagger docs features enabled

### DIFF
--- a/rocket-okapi/Cargo.toml
+++ b/rocket-okapi/Cargo.toml
@@ -18,10 +18,10 @@ rocket_okapi_codegen = { version = "=0.8.0-rc.1", path = "../rocket-okapi-codege
 serde = "1.0"
 serde_json = "1.0"
 log = "0.4"
-# Rocket dependencie but not re-exposed (update to 0.3 is Rocket master)
+# Rocket dependency but not re-exported
 # See issue: https://github.com/GREsau/schemars/issues/104
 # time = { version = "0.2.27" }
-# Rocket dependencie but not re-exposed
+# Rocket dependency but not re-exported
 either = "1"
 
 [features]
@@ -37,9 +37,12 @@ swagger = []
 rapidoc = []
 # Allow the use of UUIDs
 uuid = ["rocket/uuid", "schemars/uuid"]
-# Re-expost Rocket feature flag
+# Re-export Rocket feature flag
 # https://docs.rs/rocket/0.5.0-rc.1/rocket/serde/msgpack/struct.MsgPack.html
 msgpack = ["rocket/msgpack"]
-# Re-expost Rocket feature flag
+# Re-export Rocket feature flag
 # https://rocket.rs/v0.5-rc/guide/requests/#secret-key
 secrets = ["rocket/secrets"]
+
+[package.metadata.docs.rs]
+features = ["swagger", "rapidoc"]

--- a/rocket-okapi/src/rapidoc.rs
+++ b/rocket-okapi/src/rapidoc.rs
@@ -1,3 +1,34 @@
+//! ### Example
+//! ```rust,no_run
+//! use rocket_okapi::settings::UrlObject;
+//! use rocket_okapi::rapidoc::{make_rapidoc, RapiDocConfig, GeneralConfig};
+//!
+//! fn get_rapi_docs() -> RapiDocConfig {
+//!     RapiDocConfig {
+//!         general: GeneralConfig {
+//!             spec_urls: get_urls(), // this is the only required field
+//!             ..Default::default()
+//!         },
+//!         ..Default::default()
+//!     }
+//! }
+//!
+//! fn get_urls() -> Vec<UrlObject> {
+//!     vec![
+//!         UrlObject::new("Resource", "/my_resource/openapi.json"),
+//!     ]
+//! }
+//!
+//! #[rocket::main]
+//! async fn main() {
+//!     rocket::build()
+//!         .mount("/rapi-doc", make_rapidoc(&get_rapi_docs()))
+//!         .launch()
+//!         .await
+//!         .unwrap();
+//! }
+//! ```
+
 use crate::handlers::{ContentHandler, RedirectHandler};
 use crate::settings::UrlObject;
 use rocket::http::ContentType;


### PR DESCRIPTION
It is useful to display the structs and functions in the swagger and rapi doc modules on docs.rs. I also added an example to the rapi-docs module and fixed a couple of typos in Cargo.toml.