### PR TITLE
use multipart/form-data for rocket form submit

### DIFF
--- a/rocket-okapi/src/request/from_data_impls.rs
+++ b/rocket-okapi/src/request/from_data_impls.rs
@@ -137,7 +137,7 @@ impl<'r> OpenApiFromData<'r> for Data<'r> {
 // `OpenApiFromForm` is correct, not a mistake, as Rocket requires `FromForm`.
 impl<'r, T: JsonSchema + super::OpenApiFromForm<'r>> OpenApiFromData<'r> for rocket::form::Form<T> {
     fn request_body(gen: &mut OpenApiGenerator) -> Result {
-        fn_request_body!(gen, T, "application/octet-stream")
+        fn_request_body!(gen, T, "multipart/form-data")
     }
 }
 


### PR DESCRIPTION
changing the octet-stream here to multipart/form-data. Rocket seems to return a 404 because it doesn't expect octet-stream on a form post. Using multipart also enables a better experience w/ the swagger and rapidoc tooling where you can have a mixture of fields and files be supported there in the UI rather than an opaque blob for the request body. Should go along with https://github.com/GREsau/schemars/pull/135