### PR TITLE
migrate to Rocket 0.5.0-rc.2

### DIFF
--- a/examples/custom_schema/src/main.rs
+++ b/examples/custom_schema/src/main.rs
@@ -15,7 +15,7 @@ pub type DataResult<'a, T> =
 async fn main() {
     let launch_result = create_server().launch().await;
     match launch_result {
-        Ok(()) => println!("Rocket shut down gracefully."),
+        Ok(_) => println!("Rocket shut down gracefully."),
         Err(err) => println!("Rocket had an error: {}", err),
     };
 }

--- a/examples/json-web-api/src/main.rs
+++ b/examples/json-web-api/src/main.rs
@@ -129,7 +129,7 @@ async fn main() {
         .launch()
         .await;
     match launch_result {
-        Ok(()) => println!("Rocket shut down gracefully."),
+        Ok(_) => println!("Rocket shut down gracefully."),
         Err(err) => println!("Rocket had an error: {}", err),
     };
 }

--- a/examples/secure_request_guard/src/main.rs
+++ b/examples/secure_request_guard/src/main.rs
@@ -82,7 +82,7 @@ async fn main() {
         .launch()
         .await;
     match launch_result {
-        Ok(()) => println!("Rocket shut down gracefully."),
+        Ok(_) => println!("Rocket shut down gracefully."),
         Err(err) => println!("Rocket had an error: {}", err),
     };
 }

--- a/examples/special-types/src/main.rs
+++ b/examples/special-types/src/main.rs
@@ -70,7 +70,7 @@ async fn main() {
         .launch()
         .await;
     match launch_result {
-        Ok(()) => println!("Rocket shut down gracefully."),
+        Ok(_) => println!("Rocket shut down gracefully."),
         Err(err) => println!("Rocket had an error: {}", err),
     };
 }

--- a/examples/streams/src/main.rs
+++ b/examples/streams/src/main.rs
@@ -99,7 +99,7 @@ async fn main() {
         .launch()
         .await;
     match launch_result {
-        Ok(()) => println!("Rocket shut down gracefully."),
+        Ok(_) => println!("Rocket shut down gracefully."),
         Err(err) => println!("Rocket had an error: {}", err),
     };
 }

--- a/examples/uuid/src/main.rs
+++ b/examples/uuid/src/main.rs
@@ -99,7 +99,7 @@ async fn main() {
         .launch()
         .await;
     match launch_result {
-        Ok(()) => println!("Rocket shut down gracefully."),
+        Ok(_) => println!("Rocket shut down gracefully."),
         Err(err) => println!("Rocket had an error: {}", err),
     };
 }

--- a/rocket-okapi-codegen/Cargo.toml
+++ b/rocket-okapi-codegen/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["web-programming"]
 proc-macro = true
 
 [dependencies]
-rocket_http = { version = "0.5.0-rc.1" }
+rocket_http = { version = "0.5.0-rc.2" }
 darling = "0.13"
 syn = "1.0"
 proc-macro2 = "1.0"

--- a/rocket-okapi/Cargo.toml
+++ b/rocket-okapi/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["rust", "openapi", "swagger", "rocket"]
 categories = ["web-programming"]
 
 [dependencies]
-rocket = { version = "0.5.0-rc.1", default-features = false, features = ["json"] }
+rocket = { version = "0.5.0-rc.2", default-features = false, features = ["json"] }
 schemars = { version = "0.8" }
 okapi = { version = "0.7.0-rc.1", path = "../okapi" }
 rocket_okapi_codegen = { version = "=0.8.0-rc.1", path = "../rocket-okapi-codegen" }

--- a/rocket-okapi/src/handlers/content.rs
+++ b/rocket-okapi/src/handlers/content.rs
@@ -1,5 +1,5 @@
 use rocket::http::{ContentType, Method};
-use rocket::response::{content::Custom, Responder};
+use rocket::response::Responder;
 use rocket::route::{Handler, Outcome};
 use rocket::{Data, Request, Route};
 
@@ -7,7 +7,7 @@ use rocket::{Data, Request, Route};
 /// a `rocket::Route` that serves the content with correct content-type.
 #[derive(Clone)]
 pub struct ContentHandler<R: AsRef<[u8]> + Clone + Send + Sync> {
-    content: Custom<R>,
+    content: (ContentType, R),
 }
 
 impl ContentHandler<String> {
@@ -16,7 +16,7 @@ impl ContentHandler<String> {
         let json =
             serde_json::to_string_pretty(content).expect("Could not serialize content as JSON.");
         ContentHandler {
-            content: Custom(ContentType::JSON, json),
+            content: (ContentType::JSON, json),
         }
     }
 }
@@ -26,7 +26,7 @@ impl ContentHandler<&'static [u8]> {
     /// `content_type`.
     pub fn bytes(content_type: ContentType, content: &'static [u8]) -> Self {
         ContentHandler {
-            content: Custom(content_type, content),
+            content: (content_type, content),
         }
     }
 }
@@ -36,7 +36,7 @@ impl ContentHandler<Vec<u8>> {
     /// `content_type`.
     pub fn bytes_owned(content_type: ContentType, content: Vec<u8>) -> Self {
         ContentHandler {
-            content: Custom(content_type, content),
+            content: (content_type, content),
         }
     }
 }
@@ -58,8 +58,7 @@ where
         if req.uri().path().ends_with('/') {
             Outcome::forward(data)
         } else {
-            let content: Custom<Vec<u8>> =
-                Custom(self.content.0.clone(), self.content.1.as_ref().into());
+            let content: (_, Vec<u8>) = (self.content.0.clone(), self.content.1.as_ref().into());
             match content.respond_to(req) {
                 Ok(response) => Outcome::Success(response),
                 Err(status) => Outcome::Failure(status),

--- a/rocket-okapi/src/handlers/openapi.rs
+++ b/rocket-okapi/src/handlers/openapi.rs
@@ -1,6 +1,6 @@
 use okapi::openapi3::{OpenApi, Server};
-use rocket::http::{ContentType, Method};
-use rocket::response::content::Custom;
+use rocket::http::Method;
+use rocket::response::content::RawJson;
 use rocket::route::{Handler, Outcome};
 use rocket::{Data, Request, Route};
 
@@ -42,6 +42,6 @@ impl Handler for OpenApiHandler {
 
         let json =
             serde_json::to_string_pretty(&spec).expect("Could not serialize content as JSON.");
-        Outcome::from(req, Custom(ContentType::JSON, json))
+        Outcome::from(req, RawJson(json))
     }
 }

--- a/rocket-okapi/src/response/responder_impls.rs
+++ b/rocket-okapi/src/response/responder_impls.rs
@@ -195,14 +195,13 @@ macro_rules! response_content_wrapper {
     };
 }
 
-response_content_wrapper!(Css, "text/css");
-response_content_wrapper!(Custom, "*/*");
-response_content_wrapper!(Html, "text/html");
-response_content_wrapper!(JavaScript, "application/javascript");
-response_content_wrapper!(Json, "application/json");
-response_content_wrapper!(MsgPack, "application/msgpack");
-response_content_wrapper!(Plain, "text/plain");
-response_content_wrapper!(Xml, "text/xml");
+response_content_wrapper!(RawCss, "text/css");
+response_content_wrapper!(RawHtml, "text/html");
+response_content_wrapper!(RawJavaScript, "application/javascript");
+response_content_wrapper!(RawJson, "application/json");
+response_content_wrapper!(RawMsgPack, "application/msgpack");
+response_content_wrapper!(RawText, "text/plain");
+response_content_wrapper!(RawXml, "text/xml");
 
 macro_rules! status_responder {
     ($responder: ident, $status: literal) => {


### PR DESCRIPTION
This bumps the depended on version of Rocket to 0.5.0-rc.2, which just came out. This also requires [the pr over here](https://github.com/GREsau/schemars/pull/138) to be merged, because Rocket now depends on `uuid 1.0`. 