### PR TITLE
fixed the rocket version to "=0.5.0-rc.1"

### DIFF
--- a/rocket-okapi-codegen/Cargo.toml
+++ b/rocket-okapi-codegen/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["web-programming"]
 proc-macro = true
 
 [dependencies]
-rocket_http = { version = "0.5.0-rc.1" }
+rocket_http = { version = "=0.5.0-rc.1" }
 darling = "0.13"
 syn = "1.0"
 proc-macro2 = "1.0"

--- a/rocket-okapi/Cargo.toml
+++ b/rocket-okapi/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["rust", "openapi", "swagger", "rocket"]
 categories = ["web-programming"]
 
 [dependencies]
-rocket = { version = "0.5.0-rc.1", default-features = false, features = ["json"] }
+rocket = { version = "=0.5.0-rc.1", default-features = false, features = ["json"] }
 schemars = { version = "0.8" }
 okapi = { version = "0.7.0-rc.1", path = "../okapi" }
 rocket_okapi_codegen = { version = "=0.8.0-rc.1", path = "../rocket-okapi-codegen" }


### PR DESCRIPTION
By fixing the rocket version the build succeeds. I'm not sure why the newer version gets selected automatically. I guess until the newer version gets supported this could be a stopgap solution?

Fixes #90 