### PR TITLE
okapi: fix deserialisation for openapi3 'extensions' fields  

### DIFF
--- a/okapi/Cargo.toml
+++ b/okapi/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["web-programming"]
 
 [dependencies]
 schemars = { version = "0.8", features = ["uuid1"] }
+indexmap = { version = "1.2", features = ["serde-1"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"

--- a/okapi/src/openapi3.rs
+++ b/okapi/src/openapi3.rs
@@ -59,7 +59,8 @@ pub struct OpenApi {
     pub tags: Vec<Tag>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_docs: Option<ExternalDocs>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -78,7 +79,8 @@ pub struct Info {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub license: Option<License>,
     pub version: String,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -92,7 +94,8 @@ pub struct Contact {
     pub url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -103,7 +106,8 @@ pub struct License {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -116,7 +120,8 @@ pub struct Server {
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub variables: Map<String, ServerVariable>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -129,7 +134,8 @@ pub struct ServerVariable {
     pub default: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -163,7 +169,8 @@ pub struct PathItem {
     pub servers: Option<Vec<Server>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub parameters: Vec<RefOr<Parameter>>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -194,7 +201,8 @@ pub struct Operation {
     pub security: Option<Vec<SecurityRequirement>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub servers: Option<Vec<Server>>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -206,7 +214,8 @@ pub struct Responses {
     pub default: Option<RefOr<Response>>,
     #[serde(flatten)]
     pub responses: Map<String, RefOr<Response>>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -232,7 +241,8 @@ pub struct Components {
     pub links: Map<String, RefOr<Link>>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub callbacks: Map<String, RefOr<Callback>>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -247,7 +257,8 @@ pub struct Response {
     pub content: Map<String, MediaType>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub links: Map<String, RefOr<Link>>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -269,7 +280,8 @@ pub struct Parameter {
     pub allow_empty_value: bool,
     #[serde(flatten)]
     pub value: ParameterValue,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -320,7 +332,8 @@ pub struct Example {
     pub description: Option<String>,
     #[serde(flatten)]
     pub value: ExampleValue,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -341,7 +354,8 @@ pub struct RequestBody {
     pub content: Map<String, MediaType>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub required: bool,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -359,7 +373,8 @@ pub struct Header {
     pub allow_empty_value: bool,
     #[serde(flatten)]
     pub value: ParameterValue,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -372,7 +387,8 @@ pub struct SecurityScheme {
     // This also sets `type`
     #[serde(flatten)]
     pub data: SecuritySchemeData,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -409,7 +425,8 @@ pub enum OAuthFlows {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         refresh_url: Option<String>,
         scopes: Map<String, String>,
-        #[serde(flatten)]
+        #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
         extensions: Object,
     },
     #[serde(rename_all = "camelCase")]
@@ -418,7 +435,8 @@ pub enum OAuthFlows {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         refresh_url: Option<String>,
         scopes: Map<String, String>,
-        #[serde(flatten)]
+        #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
         extensions: Object,
     },
     #[serde(rename_all = "camelCase")]
@@ -427,7 +445,8 @@ pub enum OAuthFlows {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         refresh_url: Option<String>,
         scopes: Map<String, String>,
-        #[serde(flatten)]
+        #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
         extensions: Object,
     },
     #[serde(rename_all = "camelCase")]
@@ -437,7 +456,8 @@ pub enum OAuthFlows {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         refresh_url: Option<String>,
         scopes: Map<String, String>,
-        #[serde(flatten)]
+        #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
         extensions: Object,
     },
 }
@@ -459,7 +479,8 @@ pub struct Link {
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server: Option<Server>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -469,7 +490,8 @@ pub struct Link {
 pub struct Callback {
     #[serde(flatten)]
     pub callbacks: Map<String, PathItem>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -485,7 +507,8 @@ pub struct MediaType {
     pub examples: Option<Map<String, Example>>,
     #[serde(skip_serializing_if = "Map::is_empty")]
     pub encoding: Map<String, Encoding>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -498,7 +521,8 @@ pub struct Tag {
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_docs: Option<ExternalDocs>,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -509,7 +533,8 @@ pub struct ExternalDocs {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub url: String,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 
@@ -527,7 +552,8 @@ pub struct Encoding {
     pub explode: Option<bool>,
     #[serde(skip_serializing_if = "is_false")]
     pub allow_reserved: bool,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "preserve_order", serde(default, with = "indexmap::serde_seq"))]
+    #[cfg_attr(not(feature = "preserve_order"), serde(flatten))]
     pub extensions: Object,
 }
 


### PR DESCRIPTION
The 'extensions' fields of various structs
within okapi/src/openapi3.rs was not
deserialized correctly. 

```rust
#[serde(flatten)]
```
was empty.  

The 'extensions' fields used a custom type 'Object'.
'Object' is an alias for IndexMap or BTreeMap depending 
on feature 'preserve_order'. Deserialisation should work for both.

* [X] fix for  IndexMap (preserve_order enabled)
* [ ] fix for  BTreeMap (preserve_order disabled)

Using rocket_okapi enables the feature 'preserve_order'
by default.



Belongs to https://github.com/GREsau/okapi/issues/67