### PR TITLE
Fix docs for mount_endpoints_and_merged_docs

### DIFF
--- a/rocket-okapi/src/lib.rs
+++ b/rocket-okapi/src/lib.rs
@@ -182,9 +182,10 @@ pub fn get_openapi_route(
 ///
 /// Example:
 /// ```rust,ignore
+/// let settings = OpenApiSettings::default();
 /// let custom_route_spec = (vec![], custom_spec());
 /// mount_endpoints_and_merged_docs! {
-///     building_rocket, "/v1".to_owned(),
+///     building_rocket, "/v1".to_owned(), settings,
 ///     "/" => custom_route_spec,
 ///     "/post" => post::get_routes_and_docs(),
 ///     "/message" => message::get_routes_and_docs(),


### PR DESCRIPTION
The docs for mount_endpoints_and_merged_docs don't seem to pass a settings object which causes a confusing error.

This PR corrects those docs