### PR TITLE
add #[openapi(deprecated)]

### DIFF
--- a/rocket-okapi-codegen/src/openapi_attr/mod.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/mod.rs
@@ -27,6 +27,9 @@ struct OpenApiAttribute {
     /// Ignore certain parameters from the function and do not include them in the documentation.
     #[darling(multiple)]
     pub ignore: Vec<String>,
+
+    /// Mark this operation as deprecated in the documentation.
+    pub deprecated: bool,
 }
 
 pub fn parse(args: TokenStream, input: TokenStream) -> TokenStream {
@@ -297,6 +300,7 @@ fn create_route_operation_fn(
         .iter()
         .map(|tag| quote!(#tag.to_owned()))
         .collect::<Vec<_>>();
+    let deprecated = entry_attributes.deprecated;
 
     TokenStream::from(quote! {
         #[doc(hidden)]
@@ -368,6 +372,7 @@ fn create_route_operation_fn(
                     description: #desc,
                     security,
                     tags: vec![#(#tags),*],
+                    deprecated: #deprecated,
                     ..Default::default()
                 },
             });

--- a/rocket-okapi/Cargo.toml
+++ b/rocket-okapi/Cargo.toml
@@ -27,6 +27,7 @@ rocket_dyn_templates = { version = "=0.1.0-rc.2", optional = true }
 rocket_db_pools = { version = "=0.1.0-rc.2", optional = true }
 
 [dev-dependencies]
+rocket = { version = "=0.5.0-rc.2", default-features = false, features = ["json"] }
 rocket_sync_db_pools = { version = "0.1.0-rc.2", features = ["diesel_sqlite_pool"] }
 
 [features]

--- a/rocket-okapi/src/util.rs
+++ b/rocket-okapi/src/util.rs
@@ -108,7 +108,7 @@ pub fn add_media_type(
 /// Replaces the Content-Type for all responses with `content_type`.
 pub fn set_content_type(responses: &mut Responses, content_type: impl ToString) -> Result<()> {
     for ref mut resp_refor in responses.responses.values_mut() {
-        let response = ensure_not_ref(*resp_refor)?;
+        let response = ensure_not_ref(resp_refor)?;
         let content = &mut response.content;
         let mt = if content.values().len() == 1 {
             content.values().next().unwrap().clone()

--- a/rocket-okapi/tests/deprecated.rs
+++ b/rocket-okapi/tests/deprecated.rs
@@ -1,0 +1,52 @@
+//! This test ensures that routes can be marked as deprecated by using `#[openapi(deprecated)]`.
+
+use rocket_okapi::openapi_get_spec;
+
+// These functions are never actually called.
+#[allow(unused)]
+mod endpoints {
+    use rocket::{get, serde::json::Json};
+    use rocket_okapi::openapi;
+
+    #[openapi(deprecated = true)]
+    #[get("/explicit")]
+    pub fn explicit_controller() -> Json<()> {
+        Json(())
+    }
+
+    #[openapi(deprecated)]
+    #[get("/implicit")]
+    pub fn implicit_controller() -> Json<()> {
+        Json(())
+    }
+
+    #[openapi]
+    #[get("/default")]
+    pub fn default_controller() -> Json<()> {
+        Json(())
+    }
+}
+
+#[test]
+fn deprecated_with_explicit_value_is_deprecated() {
+    let spec = openapi_get_spec![endpoints::explicit_controller];
+
+    let operation = spec.paths["/explicit"].get.as_ref().unwrap();
+    assert!(operation.deprecated);
+}
+
+#[test]
+fn deprecated_with_implicit_value_is_deprecated() {
+    let spec = openapi_get_spec![endpoints::implicit_controller];
+
+    let operation = spec.paths["/implicit"].get.as_ref().unwrap();
+    assert!(operation.deprecated);
+}
+
+#[test]
+fn default_is_not_deprecated() {
+    let spec = openapi_get_spec![endpoints::default_controller];
+
+    let operation = spec.paths["/default"].get.as_ref().unwrap();
+    assert!(!operation.deprecated);
+}


### PR DESCRIPTION
This PR allows operations to be marked as deprecated by using the attribute `#[openapi(deprecated)]`.

Closes #106 