### PR TITLE
README.md - fixing link to uuid examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Example of generated documentation using Okapi:
 
 ## Examples
 - [Json web API](examples/json-web-api): Simple example showing the basics of Okapi.
-- [UUID](examples/uuid): Simple example showing basics, but using UUID's instead of
+- [UUID](examples/uuid_usage): Simple example showing basics, but using UUID's instead of
 normal `u32`/`u64` id's.
 - [Custom Schema](examples/custom_schema): Shows how to add more/custom info to OpenAPI file
 and merge multiple modules into one OpenAPI file.


### PR DESCRIPTION
currently link to uuid examples is not working: should be suffixed with `_usage`


<img width="690" alt="image" src="https://github.com/GREsau/okapi/assets/26941332/21859101-ab37-497b-8f95-07deac2fc5b1">


