### PR TITLE
Bump Rocket to 0.5.1 and use workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,15 @@ members = [
     "examples/websocket",
 ]
 resolver = "2"
+
+[workspace.dependencies]
+log = "0.4"
+rocket = { version = "=0.5.0", default-features = false, features = [ "json" ] }
+rocket_ws = "0.1.0"
+rocket_http = "=0.5.0"
+rocket_dyn_templates = "=0.1.0"
+rocket_db_pools = "=0.1.0"
+rocket_sync_db_pools = "=0.1.0"
+schemars = "0.8"
+serde = "1.0"
+serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ resolver = "2"
 
 [workspace.dependencies]
 log = "0.4"
-rocket = { version = "=0.5.0", default-features = false, features = [ "json" ] }
-rocket_ws = "0.1.0"
-rocket_http = "=0.5.0"
-rocket_dyn_templates = "=0.1.0"
+rocket = { version = "=0.5.1", default-features = false, features = [ "json" ] }
+rocket_ws = "0.1.1"
+rocket_http = "=0.5.1"
+rocket_dyn_templates = "=0.2.0"
 rocket_db_pools = "=0.1.0"
 rocket_sync_db_pools = "=0.1.0"
 schemars = "0.8"

--- a/examples/custom_schema/Cargo.toml
+++ b/examples/custom_schema/Cargo.toml
@@ -5,7 +5,7 @@ authors = [ "Ralph Bisschops <ralph.bisschops.dev@gmail.com>" ]
 edition = "2021"
 
 [dependencies]
-rocket = { version = "=0.5.0", default-features = false, features = [ "json" ] }
+rocket = { workspace = true }
 rocket_okapi = { path = "../../rocket-okapi", features = [ "swagger", "rapidoc" ] }
-serde = "1.0"
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/examples/dyn_templates/Cargo.toml
+++ b/examples/dyn_templates/Cargo.toml
@@ -5,9 +5,9 @@ authors = [ "Ralph Bisschops <ralph.bisschops.dev@gmail.com>" ]
 edition = "2021"
 
 [dependencies]
-rocket = { version = "=0.5.0", default-features = false, features = [ "json" ] }
-schemars = { version = "0.8" }
+rocket = { workspace = true }
+schemars = { workspace = true }
 rocket_okapi = { path = "../../rocket-okapi", features = [ "swagger", "rapidoc", "rocket_dyn_templates" ] }
-serde = "1.0"
-rocket_dyn_templates = { version = "=0.1.0", features = [ "handlebars" ] }
+serde = { workspace = true }
+rocket_dyn_templates = { workspace = true, features = [ "handlebars" ] }
 handlebars = "5.0.0"

--- a/examples/json-web-api/Cargo.toml
+++ b/examples/json-web-api/Cargo.toml
@@ -5,6 +5,6 @@ authors = [ "Graham Esau <gesau@hotmail.co.uk>" ]
 edition = "2021"
 
 [dependencies]
-rocket = { version = "=0.5.0", default-features = false, features = [ "json" ] }
+rocket = { workspace = true }
 rocket_okapi = { path = "../../rocket-okapi", features = [ "swagger", "rapidoc" ] }
-serde = "1.0"
+serde = { workspace = true }

--- a/examples/nested/Cargo.toml
+++ b/examples/nested/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
 edition = "2021"
 
 [dependencies]
-rocket = { version = "=0.5.0", default-features = false, features = [ "json" ] }
+rocket = { workspace = true }
 rocket_okapi = { path = "../../rocket-okapi", features = [ "rapidoc" ] }
-serde = "1.0"
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/examples/openapi_attributes/Cargo.toml
+++ b/examples/openapi_attributes/Cargo.toml
@@ -5,6 +5,6 @@ authors = [ "Ralph Bisschops <ralph.bisschops.dev@gmail.com>" ]
 edition = "2021"
 
 [dependencies]
-rocket = { version = "=0.5.0", default-features = false, features = [ "json" ] }
+rocket = { workspace = true }
 rocket_okapi = { path = "../../rocket-okapi", features = [ "swagger", "rapidoc" ] }
-serde = "1.0"
+serde = { workspace = true }

--- a/examples/raw_identifiers/Cargo.toml
+++ b/examples/raw_identifiers/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rocket = { version = "=0.5.0", default-features = false, features = [ "json" ] }
+rocket = { workspace = true }
 rocket_okapi = { path = "../../rocket-okapi", features = [ "rapidoc", "swagger" ] }

--- a/examples/secure_request_guard/Cargo.toml
+++ b/examples/secure_request_guard/Cargo.toml
@@ -8,8 +8,8 @@ authors = [
 edition = "2021"
 
 [dependencies]
-rocket = { version = "=0.5.0", default-features = false, features = [ "json", "secrets" ] }
+rocket = { workspace = true, features = [ "json", "secrets" ] }
 rocket_okapi = { path = "../../rocket-okapi", features = [ "rapidoc", "swagger", "secrets" ] }
-serde = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = "1.6"
-serde_json = "1.0"

--- a/examples/secure_request_guard/src/api_key.rs
+++ b/examples/secure_request_guard/src/api_key.rs
@@ -15,6 +15,7 @@ use rocket_okapi::{
     request::{OpenApiFromRequest, RequestHeaderInput},
 };
 
+#[allow(dead_code)]
 pub struct ApiKey(String);
 
 // Implement the actual checks for the authentication

--- a/examples/secure_request_guard/src/cookies.rs
+++ b/examples/secure_request_guard/src/cookies.rs
@@ -14,6 +14,7 @@ use rocket_okapi::{
     request::{OpenApiFromRequest, RequestHeaderInput},
 };
 
+#[allow(dead_code)]
 pub struct CookieAuth(String);
 
 // Implement the actual checks for the authentication

--- a/examples/secure_request_guard/src/http_auth.rs
+++ b/examples/secure_request_guard/src/http_auth.rs
@@ -15,6 +15,7 @@ use rocket_okapi::{
     request::{OpenApiFromRequest, RequestHeaderInput},
 };
 
+#[allow(dead_code)]
 pub struct HttpAuth(String);
 
 // Implement the actual checks for the authentication

--- a/examples/secure_request_guard/src/open_id.rs
+++ b/examples/secure_request_guard/src/open_id.rs
@@ -14,6 +14,7 @@ use rocket_okapi::{
     request::{OpenApiFromRequest, RequestHeaderInput},
 };
 
+#[allow(dead_code)]
 pub struct OpenId(String);
 
 // Implement the actual checks for the authentication

--- a/examples/special-types/Cargo.toml
+++ b/examples/special-types/Cargo.toml
@@ -5,6 +5,6 @@ authors = [ "Ralph Bisschops <ralph.bisschops.dev@gmail.com>" ]
 edition = "2021"
 
 [dependencies]
-rocket = { version = "=0.5.0", default-features = false, features = [ "json" ] }
+rocket = { workspace = true }
 rocket_okapi = { path = "../../rocket-okapi", features = [ "swagger", "rapidoc" ] }
-serde = "1.0"
+serde = { workspace = true }

--- a/examples/streams/Cargo.toml
+++ b/examples/streams/Cargo.toml
@@ -5,6 +5,6 @@ authors = [ "Ralph Bisschops <ralph.bisschops.dev@gmail.com>" ]
 edition = "2021"
 
 [dependencies]
-rocket = { version = "=0.5.0", default-features = false, features = [ "json" ] }
+rocket = { workspace = true }
 rocket_okapi = { path = "../../rocket-okapi", features = [ "swagger", "rapidoc" ] }
-serde = "1.0"
+serde = { workspace = true }

--- a/examples/uuid_usage/Cargo.toml
+++ b/examples/uuid_usage/Cargo.toml
@@ -9,8 +9,8 @@ authors = [
 edition = "2021"
 
 [dependencies]
-rocket = { version = "=0.5.0", default-features = false, features = [ "json", "uuid" ] }
-schemars = { version = "0.8", features = [ "uuid1" ] }
+rocket = { workspace = true, features = [ "json", "uuid" ] }
+schemars = { workspace = true, features = [ "uuid1" ] }
 rocket_okapi = { path = "../../rocket-okapi", features = [ "swagger", "rapidoc", "uuid" ] }
-serde = "1.0"
+serde = { workspace = true }
 uuid = { version = "1.1.1", features = [ "v4" ] }

--- a/examples/websocket/Cargo.toml
+++ b/examples/websocket/Cargo.toml
@@ -5,7 +5,7 @@ authors = [ "Ralph Bisschops <ralph.bisschops.dev@gmail.com>" ]
 edition = "2021"
 
 [dependencies]
-rocket = { version = "=0.5.0", default-features = false, features = [ "json" ] }
-rocket_ws = "0.1.0"
+rocket = { workspace = true }
+rocket_ws = { workspace = true }
 rocket_okapi = { path = "../../rocket-okapi", features = [ "swagger", "rapidoc", "rocket_ws" ] }
-serde = "1.0"
+serde = { workspace = true }

--- a/okapi/Cargo.toml
+++ b/okapi/Cargo.toml
@@ -11,10 +11,10 @@ keywords = [ "rust", "openapi", "swagger" ]
 categories = [ "web-programming" ]
 
 [dependencies]
-schemars = { version = "0.8" }
-serde = { version = "1.0", features = [ "derive" ] }
-serde_json = "1.0"
-log = "0.4"
+schemars = { workspace = true }
+serde = { workspace = true, features = [ "derive" ] }
+serde_json = { workspace = true }
+log = { workspace = true }
 
 [features]
 # Implements `JsonSchema` for `Schemars` and `Okapi` types themselves.

--- a/rocket-okapi-codegen/Cargo.toml
+++ b/rocket-okapi-codegen/Cargo.toml
@@ -14,7 +14,7 @@ categories = [ "web-programming" ]
 proc-macro = true
 
 [dependencies]
-rocket_http = { version = "=0.5.0" }
+rocket_http = { workspace = true }
 darling = "0.13"
 syn = "1.0"
 proc-macro2 = "1.0"

--- a/rocket-okapi-codegen/src/openapi_attr/route_attr.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/route_attr.rs
@@ -10,6 +10,7 @@ use syn::{Attribute, Meta, MetaList, NestedMeta};
 pub struct Route {
     pub method: Method,
     pub origin: Origin<'static>,
+    #[allow(dead_code)]
     pub media_type: Option<MediaType>,
     pub data_param: Option<String>,
 }

--- a/rocket-okapi/Cargo.toml
+++ b/rocket-okapi/Cargo.toml
@@ -11,20 +11,20 @@ keywords = [ "rust", "openapi", "swagger", "rocket" ]
 categories = [ "web-programming" ]
 
 [dependencies]
-rocket = { version = "=0.5.0", default-features = false, features = [ "json" ] }
-schemars = { version = "0.8.16" }
+rocket = { workspace = true }
+schemars = { workspace = true }
 okapi = { version = "0.7.0", path = "../okapi" }
 rocket_okapi_codegen = { version = "=0.8.0", path = "../rocket-okapi-codegen" }
-serde = "1.0"
-serde_json = "1.0"
-log = "0.4"
+serde = { workspace = true }
+serde_json = { workspace = true }
+log = { workspace = true }
 # Rocket dependency but not re-exported
 # See issue: https://github.com/GREsau/schemars/issues/104
 # time = { version = "0.2.27" }
-rocket_dyn_templates = { version = "=0.1.0", optional = true }
-rocket_db_pools = { version = "=0.1.0", optional = true }
-rocket_sync_db_pools = { version = "=0.1.0", optional = true }
-rocket_ws = { version = "=0.1.0", optional = true }
+rocket_dyn_templates = { workspace = true, optional = true }
+rocket_db_pools = { workspace = true, optional = true }
+rocket_sync_db_pools = { workspace = true, optional = true }
+rocket_ws = { workspace = true, optional = true }
 
 [dev-dependencies]
 rocket_sync_db_pools = { version = "0.1.0", features = [ "diesel_sqlite_pool" ] }

--- a/rocket-okapi/src/lib.rs
+++ b/rocket-okapi/src/lib.rs
@@ -134,11 +134,11 @@ pub fn get_openapi_route(
 /// The macro expects the following arguments:
 /// - rocket_builder: `Rocket<Build>`,
 /// - base_path: `&str`, `String` or [`Uri`](rocket::http::uri::Uri). (Anything that implements `ToString`)
-/// Anything accepted by [`mount()`](https://docs.rs/rocket/0.5.0/rocket/struct.Rocket.html#method.mount)
+///   Anything accepted by [`mount()`](https://docs.rs/rocket/0.5.0/rocket/struct.Rocket.html#method.mount)
 /// - openapi_settings: `OpenApiSettings` (use `OpenApiSettings::default()` if default settings are okay for you),
 /// - List of (0 or more):
 ///   - path:  `&str`, `String` or [`Uri`](rocket::http::uri::Uri).
-///   Anything accepted by `mount()` (`base_path` should not be included).
+///     Anything accepted by `mount()` (`base_path` should not be included).
 ///   - `=>`: divider
 ///   - route_and_docs: `(Vec<rocket::Route>, OpenApi)`
 ///
@@ -190,7 +190,7 @@ macro_rules! mount_endpoints_and_merged_docs {
 /// The macro expects the following arguments:
 /// - List of (0 or more):
 ///   - path:  `&str`, `String` or [`Uri`](rocket::http::uri::Uri).
-///   Anything accepted by `mount()` (`base_path` should not be included).
+///     Anything accepted by `mount()` (`base_path` should not be included).
 ///   - `=>`: divider
 ///   - route_and_docs: `(Vec<rocket::Route>, OpenApi)`
 ///

--- a/rocket-okapi/src/request/mod.rs
+++ b/rocket-okapi/src/request/mod.rs
@@ -86,7 +86,7 @@ pub enum RequestHeaderInput {
     /// - The url
     /// - The description
     /// - Variable mapping: A map between a variable name and its value.
-    /// The value is used for substitution in the server’s URL template.
+    ///   The value is used for substitution in the server’s URL template.
     Server(
         String,
         Option<String>,


### PR DESCRIPTION
This PR supersedes https://github.com/GREsau/okapi/pull/148

It does does a few things, each in a separate commit.

- First up, most dependencies are now managed via the workspace.dependency feature.
- The rocket dependencies have been bumped. Everything should now be up-to-date. Tests are passing
- Fixed a few documentation clippy lints