### PR TITLE
codegen: fix uses of reserved keyword `gen`

### DIFF
--- a/rocket-okapi-codegen/src/lib.rs
+++ b/rocket-okapi-codegen/src/lib.rs
@@ -122,10 +122,10 @@ pub fn open_api_from_request_derive(input: TokenStream) -> TokenStream {
     let ast: syn::DeriveInput = syn::parse(input).unwrap();
     let name = &ast.ident;
 
-    let gen = quote! {
+    let generator = quote! {
         impl<'r> rocket_okapi::request::OpenApiFromRequest<'r> for #name {
             fn from_request_input(
-                _gen: &mut rocket_okapi::gen::OpenApiGenerator,
+                _gen: &mut rocket_okapi::r#gen::OpenApiGenerator,
                 _name: String,
                 _required: bool,
             ) -> rocket_okapi::Result<rocket_okapi::request::RequestHeaderInput> {
@@ -133,7 +133,7 @@ pub fn open_api_from_request_derive(input: TokenStream) -> TokenStream {
             }
         }
     };
-    gen.into()
+    generator.into()
 }
 
 fn get_add_operation_fn_name(route_fn_name: &Ident) -> Ident {

--- a/rocket-okapi-codegen/src/openapi_attr/mod.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/mod.rs
@@ -68,7 +68,7 @@ fn create_empty_route_operation_fn(route_fn: ItemFn) -> TokenStream {
     TokenStream::from(quote! {
         #[doc(hidden)]
         pub fn #fn_name(
-            _gen: &mut ::rocket_okapi::gen::OpenApiGenerator,
+            _gen: &mut ::rocket_okapi::r#gen::OpenApiGenerator,
             _op_id: String,
         ) -> ::rocket_okapi::Result<()> {
             Ok(())
@@ -173,7 +173,7 @@ fn create_route_operation_fn(
         };
         params_names_used.push(arg.to_owned());
         params.push(quote! {
-            <#ty as ::rocket_okapi::request::OpenApiFromParam>::path_parameter(gen, #arg.to_owned())?.into()
+            <#ty as ::rocket_okapi::request::OpenApiFromParam>::path_parameter(generator, #arg.to_owned())?.into()
         })
     }
     // Multi Path parameters: `/<path..>`
@@ -191,7 +191,7 @@ fn create_route_operation_fn(
             };
             params_names_used.push(arg.to_owned());
             params.push(quote! {
-                <#ty as ::rocket_okapi::request::OpenApiFromSegments>::path_multi_parameter(gen, #arg.to_owned())?.into()
+                <#ty as ::rocket_okapi::request::OpenApiFromSegments>::path_multi_parameter(generator, #arg.to_owned())?.into()
             })
         }
     }
@@ -211,7 +211,7 @@ fn create_route_operation_fn(
         };
         params_names_used.push(arg.to_owned());
         params_nested_list.push(quote! {
-            <#ty as ::rocket_okapi::request::OpenApiFromForm>::form_multi_parameter(gen, #arg.to_owned(), true)?.into()
+            <#ty as ::rocket_okapi::request::OpenApiFromForm>::form_multi_parameter(generator, #arg.to_owned(), true)?.into()
         })
     }
     // Multi Query parameters: `/?<param..>`
@@ -229,7 +229,7 @@ fn create_route_operation_fn(
         };
         params_names_used.push(arg.to_owned());
         params_nested_list.push(quote! {
-            <#ty as ::rocket_okapi::request::OpenApiFromForm>::form_multi_parameter(gen, #arg.to_owned(), true)?.into()
+            <#ty as ::rocket_okapi::request::OpenApiFromForm>::form_multi_parameter(generator, #arg.to_owned(), true)?.into()
         })
     }
 
@@ -246,7 +246,7 @@ fn create_route_operation_fn(
             // Add parameter to list
             params_names_used.push(data_param.clone());
             quote! {
-                Some(<#ty as ::rocket_okapi::request::OpenApiFromData>::request_body(gen)?.into())
+                Some(<#ty as ::rocket_okapi::request::OpenApiFromData>::request_body(generator)?.into())
             }
         }
         None => quote! { None },
@@ -264,10 +264,10 @@ fn create_route_operation_fn(
         if !params_names_used.contains(arg) {
             params_names_used.push(arg.to_owned());
             params_request_guards.push(quote! {
-                <#ty as ::rocket_okapi::request::OpenApiFromRequest>::from_request_input(gen, #arg.to_owned(), true)?.into()
+                <#ty as ::rocket_okapi::request::OpenApiFromRequest>::from_request_input(generator, #arg.to_owned(), true)?.into()
             });
             request_guard_responses.push(quote! {
-                <#ty as ::rocket_okapi::request::OpenApiFromRequest>::get_responses(gen)?.into()
+                <#ty as ::rocket_okapi::request::OpenApiFromRequest>::get_responses(generator)?.into()
             });
         }
     }
@@ -323,10 +323,10 @@ fn create_route_operation_fn(
     TokenStream::from(quote! {
         #[doc(hidden)]
         pub fn #fn_name(
-            gen: &mut ::rocket_okapi::gen::OpenApiGenerator,
+            generator: &mut ::rocket_okapi::r#gen::OpenApiGenerator,
             operation_id: String,
         ) -> ::rocket_okapi::Result<()> {
-            let mut responses = <#return_type as ::rocket_okapi::response::OpenApiResponder>::responses(gen)?;
+            let mut responses = <#return_type as ::rocket_okapi::response::OpenApiResponder>::responses(generator)?;
             // Add responses from Request Guards.
             let request_guard_responses = vec![#(#request_guard_responses),*];
             for request_guard_response in request_guard_responses {
@@ -363,7 +363,7 @@ fn create_route_operation_fn(
                     // Add Security Schemes, different section.
                     RequestHeaderInput::Security(name, schema, requirement) => {
                         // Add/replace the security scheme (global).
-                        gen.add_security_scheme(name, schema);
+                        generator.add_security_scheme(name, schema);
                         // Add the security scheme that are quired for all the route.
                         security_requirements.push(requirement);
                     }
@@ -394,7 +394,7 @@ fn create_route_operation_fn(
                 Some(server_requirements)
             };
             // Add route/endpoint to OpenApi object.
-            gen.add_operation(::rocket_okapi::OperationInfo {
+            generator.add_operation(::rocket_okapi::OperationInfo {
                 path: #path.to_owned(),
                 method: ::rocket::http::Method::#method,
                 operation: ::rocket_okapi::okapi::openapi3::Operation {

--- a/rocket-okapi-codegen/src/openapi_spec.rs
+++ b/rocket-okapi-codegen/src/openapi_spec.rs
@@ -10,9 +10,9 @@ pub fn create_openapi_spec(routes: TokenStream) -> Result<TokenStream2> {
     let add_operations = create_add_operations(paths);
     Ok(quote! {
         |settings: &::rocket_okapi::settings::OpenApiSettings| -> ::rocket_okapi::okapi::openapi3::OpenApi {
-            let mut gen = ::rocket_okapi::gen::OpenApiGenerator::new(settings);
+            let mut generator = ::rocket_okapi::r#gen::OpenApiGenerator::new(settings);
             #add_operations
-            let mut spec = gen.into_openapi();
+            let mut spec = generator.into_openapi();
             let mut info = ::rocket_okapi::okapi::openapi3::Info {
                 title: env!("CARGO_PKG_NAME").to_owned(),
                 version: env!("CARGO_PKG_VERSION").to_owned(),
@@ -47,7 +47,7 @@ fn create_add_operations(paths: Punctuated<Path, Comma>) -> TokenStream2 {
         let fn_name = fn_name_for_add_operation(path.clone());
         let operation_id = operation_id(&path);
         quote! {
-            #fn_name(&mut gen, #operation_id.to_owned())
+            #fn_name(&mut generator, #operation_id.to_owned())
                 .expect(&format!("Could not generate OpenAPI operation for `{}`.", stringify!(#path)));
         }
     });


### PR DESCRIPTION
This broke rust-analyzer in recent rust versions.

Fix bug #166